### PR TITLE
누락되거나 잘못 설정된 모듈간 의존성 수정, RxCocoaRuntime 모듈 에러 수정

### DIFF
--- a/.package.resolved
+++ b/.package.resolved
@@ -1,15 +1,6 @@
 {
   "pins" : [
     {
-      "identity" : "rxswift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ReactiveX/RxSwift.git",
-      "state" : {
-        "revision" : "b4307ba0b6425c0ba4178e138799946c3da594f8",
-        "version" : "6.5.0"
-      }
-    },
-    {
       "identity" : "snapkit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SnapKit/SnapKit.git",

--- a/Projects/Core/CoreDIContainer/Project.swift
+++ b/Projects/Core/CoreDIContainer/Project.swift
@@ -11,9 +11,7 @@ import ProjectDescriptionHelpers
 let project = Project.makeModule(
     name: Modules.Core(.CoreDIContainer).name,
     product: .framework,
-    packages: [
-        .SPM.RxSwift.package
-    ],
+    packages: [],
     dependencies: [
         .Project.module(.Utils).dependency,
         .SPM.RxSwift.dependency,

--- a/Projects/Core/CoreEntity/Project.swift
+++ b/Projects/Core/CoreEntity/Project.swift
@@ -11,13 +11,7 @@ import ProjectDescriptionHelpers
 let project = Project.makeModule(
     name: Modules.Core(.CoreEntity).name,
     product: .framework,
-    packages: [
-        .SPM.RxSwift.package
-    ],
-    dependencies: [
-        .SPM.RxSwift.dependency,
-        .SPM.RxCocoa.dependency,
-        .SPM.RxRelay.dependency
-    ],
+    packages: [],
+    dependencies: [],
     hasTests: false
 )

--- a/Projects/Core/CoreNetworkService/Project.swift
+++ b/Projects/Core/CoreNetworkService/Project.swift
@@ -11,9 +11,7 @@ import ProjectDescriptionHelpers
 let project = Project.makeModule(
     name: Modules.Core(.CoreNetworkService).name,
     product: .framework,
-    packages: [
-        .SPM.RxSwift.package
-    ],
+    packages: [],
     dependencies: [
         .Project.module(.Core(.CoreEntity)).dependency,
         .SPM.RxSwift.dependency,

--- a/Projects/Core/CoreStorageService/Project.swift
+++ b/Projects/Core/CoreStorageService/Project.swift
@@ -11,9 +11,7 @@ import ProjectDescriptionHelpers
 let project = Project.makeModule(
     name: Modules.Core(.CoreStorageService).name,
     product: .framework,
-    packages: [
-        .SPM.RxSwift.package
-    ],
+    packages: [],
     dependencies: [
         .Project.module(.Core(.CoreEntity)).dependency,
         .SPM.RxSwift.dependency,

--- a/Projects/Features/FeatureHome/FeatureHomePresentation/Project.swift
+++ b/Projects/Features/FeatureHome/FeatureHomePresentation/Project.swift
@@ -12,10 +12,10 @@ let project = Project.makeModule(
     name: Modules.Features(.Home, .Presentation).name,
     product: .staticFramework,
     packages: [
-        .SPM.SnapKit.package,
-        .SPM.RxSwift.package
+        .SPM.SnapKit.package
     ],
     dependencies: [
+        .Project.module(.Core(.CoreEntity)).dependency,
         .Project.module(.DesignSystem).dependency,
         .Project.module(.Utils).dependency,
         .Project.module(.Features(.Home, .UseCase)).dependency,
@@ -23,6 +23,6 @@ let project = Project.makeModule(
         .SPM.SnapKit.dependency,
         .SPM.RxSwift.dependency,
         .SPM.RxRelay.dependency,
-        .SPM.RxCocoa.dependency
+        .SPM.RxCocoa.dependency,
     ]
 )

--- a/Projects/Features/FeatureHome/FeatureHomeRepository/Project.swift
+++ b/Projects/Features/FeatureHome/FeatureHomeRepository/Project.swift
@@ -11,9 +11,7 @@ import ProjectDescriptionHelpers
 let project = Project.makeModule(
     name: Modules.Features(.Home, .Repository).name,
     product: .framework,
-    packages: [
-        .SPM.RxSwift.package
-    ],
+    packages: [],
     dependencies: [
         .Project.module(.Core(.CoreDIContainer)).dependency,
         .Project.module(.Core(.CoreEntity)).dependency,

--- a/Projects/Features/FeatureHome/FeatureHomeUseCase/Project.swift
+++ b/Projects/Features/FeatureHome/FeatureHomeUseCase/Project.swift
@@ -11,9 +11,7 @@ import ProjectDescriptionHelpers
 let project = Project.makeModule(
     name: Modules.Features(.Home, .UseCase).name,
     product: .framework,
-    packages: [
-        .SPM.RxSwift.package
-    ],
+    packages: [],
     dependencies: [
         .Project.module(.Core(.CoreEntity)).dependency,
         .Project.module(.Features(.Home, .DIContainer)).dependency,

--- a/Projects/Features/FeatureLogin/FeatureLoginPresentation/Project.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginPresentation/Project.swift
@@ -12,10 +12,10 @@ let project = Project.makeModule(
     name: Modules.Features(.Login, .Presentation).name,
     product: .staticFramework,
     packages: [
-        .SPM.SnapKit.package,
-        .SPM.RxSwift.package
+        .SPM.SnapKit.package
     ],
     dependencies: [
+        .Project.module(.Core(.CoreEntity)).dependency,
         .Project.module(.DesignSystem).dependency,
         .Project.module(.Utils).dependency,
         .Project.module(.Features(.Login, .UseCase)).dependency,

--- a/Projects/Features/FeatureLogin/FeatureLoginRepository/Project.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginRepository/Project.swift
@@ -11,9 +11,7 @@ import ProjectDescriptionHelpers
 let project = Project.makeModule(
     name: Modules.Features(.Login, .Repository).name,
     product: .framework,
-    packages: [
-        .SPM.RxSwift.package
-    ],
+    packages: [],
     dependencies: [
         .Project.module(.Core(.CoreDIContainer)).dependency,
         .Project.module(.Core(.CoreEntity)).dependency,

--- a/Projects/Features/FeatureLogin/FeatureLoginUseCase/Project.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginUseCase/Project.swift
@@ -11,9 +11,7 @@ import ProjectDescriptionHelpers
 let project = Project.makeModule(
     name: Modules.Features(.Login, .UseCase).name,
     product: .framework,
-    packages: [
-        .SPM.RxSwift.package
-    ],
+    packages: [],
     dependencies: [
         .Project.module(.Core(.CoreEntity)).dependency,
         .Project.module(.Features(.Login, .DIContainer)).dependency,

--- a/Projects/Features/FeatureStoolLog/FeatureStoolLogPresentation/Project.swift
+++ b/Projects/Features/FeatureStoolLog/FeatureStoolLogPresentation/Project.swift
@@ -13,9 +13,9 @@ let project = Project.makeModule(
     product: .staticFramework,
     packages: [
         .SPM.SnapKit.package,
-        .SPM.RxSwift.package
     ],
     dependencies: [
+        .Project.module(.Core(.CoreEntity)).dependency,
         .Project.module(.DesignSystem).dependency,
         .Project.module(.Utils).dependency,
         .Project.module(.Features(.StoolLog, .UseCase)).dependency,

--- a/Projects/Features/FeatureStoolLog/FeatureStoolLogRepository/Project.swift
+++ b/Projects/Features/FeatureStoolLog/FeatureStoolLogRepository/Project.swift
@@ -11,9 +11,7 @@ import ProjectDescriptionHelpers
 let project = Project.makeModule(
     name: Modules.Features(.StoolLog, .Repository).name,
     product: .framework,
-    packages: [
-        .SPM.RxSwift.package
-    ],
+    packages: [],
     dependencies: [
         .Project.module(.Core(.CoreDIContainer)).dependency,
         .Project.module(.Core(.CoreEntity)).dependency,

--- a/Projects/Features/FeatureStoolLog/FeatureStoolLogUseCase/Project.swift
+++ b/Projects/Features/FeatureStoolLog/FeatureStoolLogUseCase/Project.swift
@@ -11,9 +11,7 @@ import ProjectDescriptionHelpers
 let project = Project.makeModule(
     name: Modules.Features(.StoolLog, .UseCase).name,
     product: .framework,
-    packages: [
-        .SPM.RxSwift.package
-    ],
+    packages: [],
     dependencies: [
         .Project.module(.Core(.CoreEntity)).dependency,
         .Project.module(.Features(.StoolLog, .DIContainer)).dependency,

--- a/Projects/Logger/Project.swift
+++ b/Projects/Logger/Project.swift
@@ -11,9 +11,7 @@ import ProjectDescriptionHelpers
 let project = Project.makeModule(
     name: Modules.Logger.name,
     product: .framework,
-    packages: [
-        .SPM.RxSwift.package
-    ],
+    packages: [],
     dependencies: [
         .Project.module(.Utils).dependency,
         .SPM.RxSwift.dependency,

--- a/Projects/Shared/SharedRepository/Project.swift
+++ b/Projects/Shared/SharedRepository/Project.swift
@@ -11,9 +11,7 @@ import ProjectDescriptionHelpers
 let project = Project.makeModule(
     name: Modules.Shared(.SharedRepository).name,
     product: .framework,
-    packages: [
-        .SPM.RxSwift.package
-    ],
+    packages: [],
     dependencies: [
         .Project.module(.Core(.CoreDIContainer)).dependency,
         .Project.module(.Core(.CoreEntity)).dependency,

--- a/Projects/Shared/SharedUseCase/Project.swift
+++ b/Projects/Shared/SharedUseCase/Project.swift
@@ -11,9 +11,7 @@ import ProjectDescriptionHelpers
 let project = Project.makeModule(
     name: Modules.Shared(.SharedUseCase).name,
     product: .framework,
-    packages: [
-        .SPM.RxSwift.package
-    ],
+    packages: [],
     dependencies: [
         .Project.module(.Core(.CoreDIContainer)).dependency,
         .Project.module(.Core(.CoreEntity)).dependency,

--- a/Projects/Utils/Project.swift
+++ b/Projects/Utils/Project.swift
@@ -11,9 +11,7 @@ import ProjectDescriptionHelpers
 let project = Project.makeModule(
     name: Modules.Utils.name,
     product: .framework,
-    packages: [
-        .SPM.RxSwift.package
-    ],
+    packages: [],
     dependencies: [
         .SPM.RxSwift.dependency,
         .SPM.RxCocoa.dependency,

--- a/Tuist/Dependencies.swift
+++ b/Tuist/Dependencies.swift
@@ -1,0 +1,20 @@
+//
+//  Dependencies.swift
+//  ProjectDescriptionHelpers
+//
+//  Created by 김상혁 on 2023/05/09.
+//
+
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let dependencies = Dependencies(
+    carthage: [],
+    swiftPackageManager: [
+        .remote(
+            url: "https://github.com/ReactiveX/RxSwift.git",
+            requirement: .upToNextMajor(from: "6.5.0")
+        )
+    ],
+    platforms: [.iOS]
+)

--- a/Tuist/ProjectDescriptionHelpers/Package+SPM.swift
+++ b/Tuist/ProjectDescriptionHelpers/Package+SPM.swift
@@ -10,14 +10,11 @@ import ProjectDescription
 public extension Package {
     enum SPM: CaseIterable {
         case SnapKit
-        case RxSwift
 
         public var package: Package {
             switch self {
             case .SnapKit:
-                return Package.package(url: "https://github.com/SnapKit/SnapKit.git", .upToNextMajor(from: "5.6.0"))
-            case .RxSwift:
-                return Package.package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "6.5.0"))
+                return .package(url: "https://github.com/SnapKit/SnapKit.git", .upToNextMajor(from: "5.6.0"))
             }
         }
 

--- a/Tuist/ProjectDescriptionHelpers/TargetDependency+SPM.swift
+++ b/Tuist/ProjectDescriptionHelpers/TargetDependency+SPM.swift
@@ -15,7 +15,12 @@ public extension TargetDependency {
         case RxRelay
         
         public var dependency: TargetDependency {
-            return .package(product: rawValue)
+            switch self {
+            case .SnapKit:
+                return .package(product: rawValue)
+            case .RxSwift, .RxCocoa, .RxRelay:
+                return .external(name: rawValue)
+            }
         }
         
         public static var allDependencies: [TargetDependency] {


### PR DESCRIPTION
### 🔖 관련 이슈
- #29 

<br> 

### ⚒️ 작업 내역

- [x] Feature-Presentation 모듈들에 CoreEntity 의존성이 누락되어있는 것 수정
- [x] CoreEntity 모듈에 불필요하게 설정된 RxSwift 의존성 제거
- [x] RxSwift에 대한 의존성을 Xcode SPM에서 Tuist SPM 방식으로 관리하도록 변경 
- [x] RxCocoaRuntime 모듈 관련 에러 수정

<br>

### 💻 리뷰어 가이드

- `tuist generate` 실행 전에 `tuist clean`, `tuist fetch` 커맨드를 순차적으로 실행해주세요.

<br>

### 📝 부가 설명

모듈간 의존성 수정 과정에서 아래 문제 상황이 발생했습니다.

- 실행 환경
  - MacOS: Ventura 13.3.1
  - Xcode: 14.1
  - Tuist Version: 3.18.0

- 문제 상황
  - FeatureHomePresentation 모듈만 따로 빌드할 때,
FeatureStoolLogDIContainer에 RxCocoaRuntime 모듈을 빠뜨렸다는 컴파일 에러가 발생합니다.

    <img src="https://user-images.githubusercontent.com/57667738/237000547-68cd2236-3ddb-441d-93d2-93d90953a5b4.png"  width=70%/>
    <img src="https://user-images.githubusercontent.com/57667738/237000535-47bae5ba-25e2-42fa-8c99-87c11a26ea74.png"  width=70%/>  


- 이해가 안되는 점
    1. FeatureStoolLogDIContainer는 RxCocoa는 물론이고 RxSwift 자체를 사용하지 않는 모듈입니다.
    (RxSwift에 의존하지 않는 모듈인데 RxCocoaRuntime 의존성이 없다고 에러 발생?)
    2. 정작 FeatureStoolLogDIContainer 모듈은 빌드가 성공적으로 잘 됩니다.
    (FeatureHomePresentation 모듈을 빌드할 때 엉뚱하게 FeatureStoolLogDIContainer에 대한 에러가 발생함)

<br>

### 해결 시도 1) FeatureStoolLogDIContainer에 RxCocoa 의존성 추가 - 해결 실패
- FeatureStoolLogDIContainer는 RxCocoa를 사용하지 않는 모듈이지만,
어쨌든 에러 내용 대로 RxCocoaRuntime 의존성을 넣어줘 봤습니다.
    ```swift
    // FeatureStoolDIContainer/Project.swift
    import ProjectDescription
    import ProjectDescriptionHelpers
    
    let project = Project.makeModule(
        name: Modules.Features(.StoolLog, .DIContainer).name,
        product: .framework,
        packages: [
            .SPM.RxSwift.package // 추가해준 코드
        ],
        dependencies: [
            .Project.module(.Utils).dependency,
            .SPM.RxCocoaRuntime.dependency // 추가해준 코드
        ],
        hasTests: false
    )
    ```
    <img src="https://user-images.githubusercontent.com/57667738/237001294-47e10724-4fc2-4874-b7f6-36e6f6c28318.png"  width=70%/>

- 실행 결과
  <img src="https://user-images.githubusercontent.com/57667738/237001386-c07f4727-eb58-4ee1-b7d1-31ed20a8a618.png"  width=70%/>
    에러 메세지가 Missing required module → Missing package product로 변경되었을 뿐, 여전히 컴파일 에러가 발생합니다.
    
<br>

### 해결 시도 2) RxSwift 의존성을 Xcode SPM 방식에서 Tuist SPM 방식으로 변경 - 해결 성공

- RxSwift의 이슈에서 이와 관련한 사례를 찾을 수 있었으나 뚜렷한 해결책을 찾지 못했습니다.
- **Xcode SPM으로 RxSwift에 대한 의존성을 관리할 때 발생하는 버그로 판단**하여,
  Xcode SPM 대신 Tuist가 제공해주는 SPM 방식으로 RxSwift에 대한 의존성을 관리하도록 변경했습니다.
  (SnapKit은 Xcode SPM 방식을 계속 사용합니다.)

  ```swift
  // Manifests/Tuist 경로에 dependencies.swift 파일 추가
  let dependencies = Dependencies(
    carthage: [],
    swiftPackageManager: [
        .remote(
            url: "https://github.com/ReactiveX/RxSwift.git",
            requirement: .upToNextMajor(from: "6.5.0")
        )
    ],
    platforms: [.iOS]
  )
  ```

- 이후 정상적으로 빌드가 되는 것을 확인했습니다.

<br> 

### 📑 첨부 자료

- [관련이슈1](https://github.com/ReactiveX/RxSwift/issues/2277)
- [관련이슈2](https://github.com/ReactiveX/RxSwift/issues/2194)

