### PR TITLE
EntityUIMapper 모듈 구현, DesignSystem+Rx 모듈 구현, deinit 로깅

### DIFF
--- a/Projects/DesignSystem/Project.swift
+++ b/Projects/DesignSystem/Project.swift
@@ -15,6 +15,7 @@ let project = Project.makeModule(
         .SPM.SnapKit.package
     ],
     dependencies: [
+        .Project.module(.Logger).dependency,
         .SPM.SnapKit.dependency
     ],
     resources: ["Resources/**"],

--- a/Projects/DesignSystem/Sources/Component/UIButton/ImageSelectionButton.swift
+++ b/Projects/DesignSystem/Sources/Component/UIButton/ImageSelectionButton.swift
@@ -1,0 +1,34 @@
+//
+//  ImageSelectionButton.swift
+//  DesignSystem
+//
+//  Created by 김상혁 on 2023/06/04.
+//  Copyright © 2023 Lifepoo. All rights reserved.
+//
+
+import UIKit
+
+public final class ImageSelectionButton: UIButton {
+    
+    public let index: Int
+    
+    public init(selectedImage: UIImage? = nil, deselectedImage: UIImage? = nil, index: Int) {
+        self.index = index
+        super.init(frame: .zero)
+        setImage(selectedImage, for: .selected)
+        setImage(deselectedImage, for: .normal)
+    }
+    
+    @available(*, unavailable)
+    public required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    public func setSelectedImage(_ image: UIImage) {
+        setImage(image, for: .selected)
+    }
+    
+    public func toggleSelection(isSelected: Bool) {
+        self.isSelected = isSelected
+    }
+}

--- a/Projects/DesignSystem/Sources/Component/UIView/FeedbackTextViewContainerView.swift
+++ b/Projects/DesignSystem/Sources/Component/UIView/FeedbackTextViewContainerView.swift
@@ -1,5 +1,5 @@
 //
-//  LifePoopTextView.swift
+//  FeedbackTextViewContainerView.swift
 //  DesignSystem
 //
 //  Created by 김상혁 on 2023/05/24.
@@ -10,9 +10,7 @@ import UIKit
 
 import SnapKit
 
-public final class FeedbackTextView: UIControl {
-    
-    private let containerView = UIView()
+public final class FeedbackTextViewContainerView: UIView {
     
     private lazy var toolbar: UIToolbar = {
         let toolbar = UIToolbar(frame: CGRect(x: .zero, y: .zero, width: UIScreen.main.bounds.width, height: 44))
@@ -83,28 +81,14 @@ public final class FeedbackTextView: UIControl {
     public required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
-    private func setPlaceholder() {
-        textView.textColor = placeholderTextColor
-        textView.text = placeholder
-    }
-    
-    @objc private func tapDoneBarButton() {
-        textView.resignFirstResponder()
-    }
 }
 
 // MARK: - UI Layout
 
-private extension FeedbackTextView {
+private extension FeedbackTextViewContainerView {
     func layoutUI() {
-        addSubview(containerView)
-        containerView.addSubview(textView)
-        containerView.addSubview(textCountLabel)
-        
-        containerView.snp.makeConstraints { make in
-            make.edges.equalToSuperview()
-        }
+        addSubview(textView)
+        addSubview(textCountLabel)
         
         textView.snp.makeConstraints { make in
             make.top.leading.trailing.equalToSuperview()
@@ -118,9 +102,22 @@ private extension FeedbackTextView {
     }
 }
 
+// MARK: - Supporting Methods
+
+private extension FeedbackTextViewContainerView {
+    private func setPlaceholder() {
+        textView.textColor = placeholderTextColor
+        textView.text = placeholder
+    }
+    
+    @objc private func tapDoneBarButton() {
+        textView.resignFirstResponder()
+    }
+}
+
 // MARK: - TextField Delegate Methods
 
-extension FeedbackTextView: UITextViewDelegate {
+extension FeedbackTextViewContainerView: UITextViewDelegate {
     public func textViewDidBeginEditing(_ textView: UITextView) {
         if isPlaceholderVisible {
             textView.text = ""

--- a/Projects/DesignSystem/Sources/Component/UIViewController/LifePoopViewController.swift
+++ b/Projects/DesignSystem/Sources/Component/UIViewController/LifePoopViewController.swift
@@ -6,7 +6,10 @@
 //  Copyright © 2023 LifePoop. All rights reserved.
 //
 
+import OSLog
 import UIKit
+
+import Logger
 
 open class LifePoopViewController: UIViewController {
     
@@ -23,4 +26,8 @@ open class LifePoopViewController: UIViewController {
     }
     
     open func layoutUI() { }
+    
+    deinit {
+        Logger.logDeallocation(object: self)
+    }
 }

--- a/Projects/DesignSystemReactive/Project.swift
+++ b/Projects/DesignSystemReactive/Project.swift
@@ -1,0 +1,21 @@
+//
+//  Project.swift
+//  ProjectDescriptionHelpers
+//
+//  Created by 김상혁 on 2023/06/06.
+//
+
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let project = Project.makeModule(
+    name: Modules.DesignSystemReactive.name,
+    product: .framework,
+    packages: [],
+    dependencies: [
+        .Project.module(.DesignSystem).dependency,
+        .SPM.RxSwift.dependency,
+        .SPM.RxCocoa.dependency,
+    ],
+    hasTests: false
+)

--- a/Projects/DesignSystemReactive/Sources/ConditionalTextField+Reactive.swift
+++ b/Projects/DesignSystemReactive/Sources/ConditionalTextField+Reactive.swift
@@ -8,12 +8,12 @@
 
 import UIKit
 
-import RxSwift
 import RxCocoa
+import RxSwift
 
 import DesignSystem
 
-public extension Reactive where Base == ConditionalTextField { // FIXME: 공통 모듈로 분리
+public extension Reactive where Base == ConditionalTextField {
     var text: ControlProperty<String> {
         base.rx.controlProperty(
             editingEvents: .valueChanged,

--- a/Projects/DesignSystemReactive/Sources/ConditionalTextField+Reactive.swift
+++ b/Projects/DesignSystemReactive/Sources/ConditionalTextField+Reactive.swift
@@ -1,0 +1,26 @@
+//
+//  ConditionalTextField+Reactive.swift
+//  DesignSystemReactive
+//
+//  Created by 김상혁 on 2023/06/06.
+//  Copyright © 2023 Lifepoo. All rights reserved.
+//
+
+import UIKit
+
+import RxSwift
+import RxCocoa
+
+import DesignSystem
+
+public extension Reactive where Base == ConditionalTextField { // FIXME: 공통 모듈로 분리
+    var text: ControlProperty<String> {
+        base.rx.controlProperty(
+            editingEvents: .valueChanged,
+            getter: { $0.text ?? "" },
+            setter: { insertField, text in
+                insertField.text = text
+            }
+        )
+    }
+}

--- a/Projects/EntityUIMapper/Project.swift
+++ b/Projects/EntityUIMapper/Project.swift
@@ -1,0 +1,21 @@
+//
+//  Project.swift
+//  ProjectDescriptionHelpers
+//
+//  Created by 김상혁 on 2023/06/01.
+//
+
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let project = Project.makeModule(
+    name: Modules.EntityUIMapper.name,
+    product: .framework,
+    packages: [],
+    dependencies: [
+        .Project.module(.Core(.CoreEntity)).dependency,
+        .Project.module(.DesignSystem).dependency,
+        .Project.module(.Utils).dependency
+    ],
+    hasTests: false
+)

--- a/Projects/EntityUIMapper/Sources/ProfileCharacter+image.swift
+++ b/Projects/EntityUIMapper/Sources/ProfileCharacter+image.swift
@@ -1,0 +1,49 @@
+//
+//  ProfileCharacter+image.swift
+//  EntityUIMapper
+//
+//  Created by 김상혁 on 2023/06/05.
+//  Copyright © 2023 Lifepoo. All rights reserved.
+//
+
+import UIKit
+
+import CoreEntity
+import DesignSystem
+
+public extension ProfileCharacter { // FIXME: Rename: stifness -> type / case stiffness -> case hard
+    var image: UIImage {
+        switch (stiffness, color) {
+        case (.normal, .black):
+            return ImageAsset.profileGoodBlack.original
+        case (.normal, .pink):
+            return ImageAsset.profileGoodRed.original
+        case (.normal, .brown):
+            return ImageAsset.profileGoodBrown.original
+        case (.normal, .green):
+            return ImageAsset.profileGoodGreen.original
+        case (.normal, .yellow):
+            return ImageAsset.profileGoodYellow.original
+        case (.stiffness, .black):
+            return ImageAsset.profileHardBlack.original
+        case (.stiffness, .brown):
+            return ImageAsset.profileHardBrown.original
+        case (.stiffness, .green):
+            return ImageAsset.profileHardGreen.original
+        case (.stiffness, .pink):
+            return ImageAsset.profileHardRed.original
+        case (.stiffness, .yellow):
+            return ImageAsset.profileHardYellow.original
+        case (.soft, .black):
+            return ImageAsset.profileSoftBlack.original
+        case (.soft, .brown):
+            return ImageAsset.profileSoftBrown.original
+        case (.soft, .green):
+            return ImageAsset.profileSoftGreen.original
+        case (.soft, .pink):
+            return ImageAsset.profileSoftRed.original
+        case (.soft, .yellow):
+            return ImageAsset.profileSoftYellow.original
+        }
+    }
+}

--- a/Projects/EntityUIMapper/Sources/SelectableColor+image.swift
+++ b/Projects/EntityUIMapper/Sources/SelectableColor+image.swift
@@ -1,0 +1,44 @@
+//
+//  SelectableColor+image.swift
+//  EntityUIMapper
+//
+//  Created by 김상혁 on 2023/06/05.
+//  Copyright © 2023 Lifepoo. All rights reserved.
+//
+
+import UIKit
+
+import CoreEntity
+import DesignSystem
+
+public extension SelectableColor {
+    var selectedImage: UIImage {
+        switch self {
+        case .brown:
+            return ImageAsset.colorBrownSelected.original
+        case .black:
+            return ImageAsset.colorBlackSelected.original
+        case .pink:
+            return ImageAsset.colorPinkSelected.original
+        case .green:
+            return ImageAsset.colorGreenSelected.original
+        case .yellow:
+            return ImageAsset.colorYellowSelected.original
+        }
+    }
+    
+    var deselectedImage: UIImage {
+        switch self {
+        case .brown:
+            return ImageAsset.colorBrownDeselected.original
+        case .black:
+            return ImageAsset.colorBlackDeselected.original
+        case .pink:
+            return ImageAsset.colorPinkDeselected.original
+        case .green:
+            return ImageAsset.colorGreenDeselected.original
+        case .yellow:
+            return ImageAsset.colorYellowDeselected.original
+        }
+    }
+}

--- a/Projects/EntityUIMapper/Sources/SelectableStiffness+image.swift
+++ b/Projects/EntityUIMapper/Sources/SelectableStiffness+image.swift
@@ -1,0 +1,25 @@
+//
+//  SelectableStiffness+image.swift
+//  EntityUIMapper
+//
+//  Created by 김상혁 on 2023/06/05.
+//  Copyright © 2023 Lifepoo. All rights reserved.
+//
+
+import UIKit
+
+import CoreEntity
+import DesignSystem
+
+public extension SelectableStiffness {
+    var deselectedImage: UIImage {
+        switch self {
+        case .soft:
+            return ImageAsset.profileSoftGray.original
+        case .normal:
+            return ImageAsset.profileGoodGray.original
+        case .stiffness:
+            return ImageAsset.profileHardGray.original
+        }
+    }
+}

--- a/Projects/Features/FeatureHome/FeatureHomeCoordinator/Project.swift
+++ b/Projects/Features/FeatureHome/FeatureHomeCoordinator/Project.swift
@@ -14,6 +14,7 @@ let project = Project.makeModule(
     packages: [],
     dependencies: [
         .Project.module(.DesignSystem).dependency,
+        .Project.module(.Logger).dependency,
         .Project.module(.Features(.Home, .Presentation)).dependency,
         .Project.module(.Features(.Home, .CoordinatorInterface)).dependency,
         .Project.module(.Features(.Setting, .Coordinator)).dependency,

--- a/Projects/Features/FeatureHome/FeatureHomePresentation/Project.swift
+++ b/Projects/Features/FeatureHome/FeatureHomePresentation/Project.swift
@@ -17,6 +17,7 @@ let project = Project.makeModule(
     dependencies: [
         .Project.module(.Core(.CoreEntity)).dependency,
         .Project.module(.DesignSystem).dependency,
+        .Project.module(.Logger).dependency,
         .Project.module(.Utils).dependency,
         .Project.module(.Features(.Home, .UseCase)).dependency,
         .Project.module(.Features(.Home, .DIContainer)).dependency,

--- a/Projects/Features/FeatureLogin/FeatureLoginCoordinator/Project.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginCoordinator/Project.swift
@@ -14,6 +14,7 @@ let project = Project.makeModule(
     packages: [],
     dependencies: [
         .Project.module(.DesignSystem).dependency,
+        .Project.module(.Logger).dependency,
         .Project.module(.Features(.Login, .Presentation)).dependency,
         .Project.module(.Features(.Login, .CoordinatorInterface)).dependency,
         .Project.module(.Utils).dependency,

--- a/Projects/Features/FeatureLogin/FeatureLoginPresentation/Project.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginPresentation/Project.swift
@@ -17,6 +17,7 @@ let project = Project.makeModule(
     dependencies: [
         .Project.module(.Core(.CoreEntity)).dependency,
         .Project.module(.DesignSystem).dependency,
+        .Project.module(.Logger).dependency,
         .Project.module(.Utils).dependency,
         .Project.module(.Features(.Login, .UseCase)).dependency,
         .Project.module(.Features(.Login, .DIContainer)).dependency,

--- a/Projects/Features/FeatureSetting/FeatureSettingCoordinator/Project.swift
+++ b/Projects/Features/FeatureSetting/FeatureSettingCoordinator/Project.swift
@@ -15,6 +15,7 @@ let project = Project.makeModule(
     dependencies: [
         .Project.module(.Core(.CoreEntity)).dependency,
         .Project.module(.DesignSystem).dependency,
+        .Project.module(.Logger).dependency,
         .Project.module(.Features(.Setting, .Presentation)).dependency,
         .Project.module(.Features(.Setting, .CoordinatorInterface)).dependency,
         .Project.module(.Utils).dependency,

--- a/Projects/Features/FeatureSetting/FeatureSettingPresentation/Project.swift
+++ b/Projects/Features/FeatureSetting/FeatureSettingPresentation/Project.swift
@@ -18,6 +18,7 @@ let project = Project.makeModule(
         .Project.module(.Core(.CoreEntity)).dependency,
         .Project.module(.DesignSystem).dependency,
         .Project.module(.DesignSystemReactive).dependency,
+        .Project.module(.Logger).dependency,
         .Project.module(.EntityUIMapper).dependency,
         .Project.module(.Utils).dependency,
         .Project.module(.Features(.Setting, .UseCase)).dependency,

--- a/Projects/Features/FeatureSetting/FeatureSettingPresentation/Project.swift
+++ b/Projects/Features/FeatureSetting/FeatureSettingPresentation/Project.swift
@@ -17,6 +17,7 @@ let project = Project.makeModule(
     dependencies: [
         .Project.module(.Core(.CoreEntity)).dependency,
         .Project.module(.DesignSystem).dependency,
+        .Project.module(.DesignSystemReactive).dependency,
         .Project.module(.EntityUIMapper).dependency,
         .Project.module(.Utils).dependency,
         .Project.module(.Features(.Setting, .UseCase)).dependency,

--- a/Projects/Features/FeatureSetting/FeatureSettingPresentation/Project.swift
+++ b/Projects/Features/FeatureSetting/FeatureSettingPresentation/Project.swift
@@ -17,6 +17,7 @@ let project = Project.makeModule(
     dependencies: [
         .Project.module(.Core(.CoreEntity)).dependency,
         .Project.module(.DesignSystem).dependency,
+        .Project.module(.EntityUIMapper).dependency,
         .Project.module(.Utils).dependency,
         .Project.module(.Features(.Setting, .UseCase)).dependency,
         .Project.module(.Features(.Setting, .DIContainer)).dependency,

--- a/Projects/Features/FeatureSetting/FeatureSettingPresentation/Sources/Feedback/FeedbackViewController.swift
+++ b/Projects/Features/FeatureSetting/FeatureSettingPresentation/Sources/Feedback/FeedbackViewController.swift
@@ -58,7 +58,7 @@ public final class FeedbackViewController: LifePoopViewController, ViewType {
         return label
     }()
     
-    private let suggestionTextView = FeedbackTextView(
+    private let suggestionTextView = FeedbackTextViewContainerView(
         placeholder: "제안하고 싶은 내용을 입력해주세요.",
         maximumTextCount: 200
     )

--- a/Projects/Features/FeatureSetting/FeatureSettingPresentation/Sources/Profile/ProfileViewController.swift
+++ b/Projects/Features/FeatureSetting/FeatureSettingPresentation/Sources/Profile/ProfileViewController.swift
@@ -13,6 +13,7 @@ import RxSwift
 import SnapKit
 
 import DesignSystem
+import EntityUIMapper
 import Utils
 
 public final class ProfileViewController: LifePoopViewController, ViewType {
@@ -204,45 +205,6 @@ private extension ProfileViewController {
     
     @objc func keyboardWillHide(notification: NSNotification) {
         scrollView.setContentOffset(.zero, animated: true)
-    }
-}
-
-import CoreEntity // FIXME: Shared Presentation 모듈로 분리
-
-extension ProfileCharacter { // FIXME: Rename: stifness -> type / case stiffness -> case hard
-    var image: UIImage {
-        switch (stiffness, color) {
-        case (.normal, .black):
-            return ImageAsset.profileGoodBlack.original
-        case (.normal, .pink):
-            return ImageAsset.profileGoodRed.original
-        case (.normal, .brown):
-            return ImageAsset.profileGoodBrown.original
-        case (.normal, .green):
-            return ImageAsset.profileGoodGreen.original
-        case (.normal, .yellow):
-            return ImageAsset.profileGoodYellow.original
-        case (.stiffness, .black):
-            return ImageAsset.profileHardBlack.original
-        case (.stiffness, .brown):
-            return ImageAsset.profileHardBrown.original
-        case (.stiffness, .green):
-            return ImageAsset.profileHardGreen.original
-        case (.stiffness, .pink):
-            return ImageAsset.profileHardRed.original
-        case (.stiffness, .yellow):
-            return ImageAsset.profileHardYellow.original
-        case (.soft, .black):
-            return ImageAsset.profileSoftBlack.original
-        case (.soft, .brown):
-            return ImageAsset.profileSoftBrown.original
-        case (.soft, .green):
-            return ImageAsset.profileSoftGreen.original
-        case (.soft, .pink):
-            return ImageAsset.profileSoftRed.original
-        case (.soft, .yellow):
-            return ImageAsset.profileSoftYellow.original
-        }
     }
 }
 

--- a/Projects/Features/FeatureSetting/FeatureSettingPresentation/Sources/Profile/ProfileViewController.swift
+++ b/Projects/Features/FeatureSetting/FeatureSettingPresentation/Sources/Profile/ProfileViewController.swift
@@ -13,6 +13,7 @@ import RxSwift
 import SnapKit
 
 import DesignSystem
+import DesignSystemReactive
 import EntityUIMapper
 import Utils
 
@@ -67,8 +68,9 @@ public final class ProfileViewController: LifePoopViewController, ViewType {
             .bind(to: input.viewDidLoad)
             .disposed(by: disposeBag)
         
-        nicknameTextField.rx // TODO: How?
-        
+        nicknameTextField.rx.text
+            .bind(to: input.nicknameDidChange)
+            .disposed(by: disposeBag)
     }
     
     public func bindOutput(from viewModel: ProfileViewModel) {
@@ -205,17 +207,5 @@ private extension ProfileViewController {
     
     @objc func keyboardWillHide(notification: NSNotification) {
         scrollView.setContentOffset(.zero, animated: true)
-    }
-}
-
-extension Reactive where Base == ConditionalTextField { // FIXME: 공통 모듈로 분리
-    var text: ControlProperty<String> {
-        base.rx.controlProperty(
-            editingEvents: .valueChanged,
-            getter: { $0.text ?? "" },
-            setter: { insertField, text in
-                insertField.text = text
-            }
-        )
     }
 }

--- a/Projects/Features/FeatureSetting/FeatureSettingPresentation/Sources/Withdrawal/WithdrawalViewController.swift
+++ b/Projects/Features/FeatureSetting/FeatureSettingPresentation/Sources/Withdrawal/WithdrawalViewController.swift
@@ -44,7 +44,7 @@ public final class WithdrawalViewController: LifePoopViewController, ViewType {
         return stackView
     }()
     
-    private let reasonTextView = FeedbackTextView(
+    private let reasonTextView = FeedbackTextViewContainerView(
         placeholder: "이 외에 불편했던 점을 작성해주세요. (선택)",
         maximumTextCount: 100
     )

--- a/Projects/Features/FeatureStoolLog/FeatureStoolLogCoordinator/Project.swift
+++ b/Projects/Features/FeatureStoolLog/FeatureStoolLogCoordinator/Project.swift
@@ -14,6 +14,7 @@ let project = Project.makeModule(
     packages: [],
     dependencies: [
         .Project.module(.DesignSystem).dependency,
+        .Project.module(.Logger).dependency,
         .Project.module(.Features(.StoolLog, .Presentation)).dependency,
         .Project.module(.Features(.StoolLog, .CoordinatorInterface)).dependency,
         .Project.module(.Utils).dependency,

--- a/Projects/Features/FeatureStoolLog/FeatureStoolLogPresentation/Project.swift
+++ b/Projects/Features/FeatureStoolLog/FeatureStoolLogPresentation/Project.swift
@@ -17,6 +17,7 @@ let project = Project.makeModule(
     dependencies: [
         .Project.module(.Core(.CoreEntity)).dependency,
         .Project.module(.DesignSystem).dependency,
+        .Project.module(.Logger).dependency,
         .Project.module(.Utils).dependency,
         .Project.module(.Features(.StoolLog, .UseCase)).dependency,
         .Project.module(.Features(.StoolLog, .DIContainer)).dependency,

--- a/Projects/Logger/Project.swift
+++ b/Projects/Logger/Project.swift
@@ -14,9 +14,7 @@ let project = Project.makeModule(
     packages: [],
     dependencies: [
         .Project.module(.Utils).dependency,
-        .SPM.RxSwift.dependency,
-        .SPM.RxCocoa.dependency,
-        .SPM.RxRelay.dependency
+        .SPM.RxSwift.dependency
     ],
     hasTests: false
 )

--- a/Projects/Logger/Sources/Logger.swift
+++ b/Projects/Logger/Sources/Logger.swift
@@ -19,8 +19,9 @@ public struct Logger {
     
     public static func logDeallocation<T: AnyObject>(object: T) {
         #if DEBUG
-        let log = OSLog(subsystem: OSLog.subsystem, category: OSLog.LogCategory.allocation.value)
-        os_log(.info, log: log, "\(T.self) deallocated")
+        let log = OSLog(subsystem: OSLog.subsystem, category: OSLog.LogCategory.deallocation.value)
+        let objectDescription = String(describing: object)
+        os_log(.info, log: log, "\(objectDescription)")
         #endif
     }
 }

--- a/Projects/Logger/Sources/OSLog+LogCategory.swift
+++ b/Projects/Logger/Sources/OSLog+LogCategory.swift
@@ -16,7 +16,7 @@ public extension OSLog {
     
     enum LogCategory {
         case `default`
-        case allocation
+        case deallocation
         case userDefaults
         case bundle
         case network
@@ -31,8 +31,8 @@ public extension OSLog {
                 return Constant.OSLogCategory.bundle
             case .userDefaults:
                 return Constant.OSLogCategory.userDefaults
-            case .allocation:
-                return Constant.OSLogCategory.allocation
+            case .deallocation:
+                return Constant.OSLogCategory.deallocation
             case .network:
                 return Constant.OSLogCategory.network
             case .database:

--- a/Projects/Utils/Sources/Constant/Constant.swift
+++ b/Projects/Utils/Sources/Constant/Constant.swift
@@ -32,7 +32,7 @@ public extension Constant {
 public extension Constant {
     enum OSLogCategory {
         public static let `default` = "Default"
-        public static let allocation = "Allocation"
+        public static let deallocation = "Deallocation"
         public static let bundle = "Bundle"
         public static let userDefaults = "UserDefaults"
         public static let network = "Network"

--- a/Tuist/ProjectDescriptionHelpers/Modules.swift
+++ b/Tuist/ProjectDescriptionHelpers/Modules.swift
@@ -10,6 +10,7 @@ import ProjectDescription
 public enum Modules {
     case App
     case DesignSystem
+    case DesignSystemReactive
     case EntityUIMapper
     case Logger
     case Utils
@@ -23,6 +24,8 @@ public enum Modules {
             return "App"
         case .DesignSystem:
             return "DesignSystem"
+        case .DesignSystemReactive:
+            return "DesignSystemReactive"
         case .EntityUIMapper:
             return "EntityUIMapper"
         case .Logger:
@@ -40,7 +43,7 @@ public enum Modules {
     
     public var path: String {
         switch self {
-        case .App, .DesignSystem, .EntityUIMapper, .Logger, .Utils:
+        case .App, .DesignSystem, .DesignSystemReactive, .EntityUIMapper, .Logger, .Utils:
             return "Projects/\(name)"
         case .Shared:
             return "Projects/Shared/\(name)"

--- a/Tuist/ProjectDescriptionHelpers/Modules.swift
+++ b/Tuist/ProjectDescriptionHelpers/Modules.swift
@@ -10,6 +10,7 @@ import ProjectDescription
 public enum Modules {
     case App
     case DesignSystem
+    case EntityUIMapper
     case Logger
     case Utils
     case Shared(SharedModuleType)
@@ -22,6 +23,8 @@ public enum Modules {
             return "App"
         case .DesignSystem:
             return "DesignSystem"
+        case .EntityUIMapper:
+            return "EntityUIMapper"
         case .Logger:
             return "Logger"
         case .Utils:
@@ -37,7 +40,7 @@ public enum Modules {
     
     public var path: String {
         switch self {
-        case .App, .DesignSystem, .Logger, .Utils:
+        case .App, .DesignSystem, .EntityUIMapper, .Logger, .Utils:
             return "Projects/\(name)"
         case .Shared:
             return "Projects/Shared/\(name)"

--- a/Tuist/ProjectDescriptionHelpers/TargetDependency+Project.swift
+++ b/Tuist/ProjectDescriptionHelpers/TargetDependency+Project.swift
@@ -27,6 +27,7 @@ public extension TargetDependency {
             
             let allDependencies = [
                 Project.module(.DesignSystem).dependency,
+                Project.module(.DesignSystemReactive).dependency,
                 Project.module(.Logger).dependency,
                 Project.module(.Utils).dependency,
                 Project.module(.EntityUIMapper).dependency,

--- a/Tuist/ProjectDescriptionHelpers/TargetDependency+Project.swift
+++ b/Tuist/ProjectDescriptionHelpers/TargetDependency+Project.swift
@@ -29,6 +29,7 @@ public extension TargetDependency {
                 Project.module(.DesignSystem).dependency,
                 Project.module(.Logger).dependency,
                 Project.module(.Utils).dependency,
+                Project.module(.EntityUIMapper).dependency,
             ] + sharedDependencies + coreDependencies + featureDependencies
             
             return allDependencies


### PR DESCRIPTION
### 🔖 관련 이슈
- #51 

<br> 

### ⚒️ 작업 내역

- [x] CoreEntity-DesignSystem Asset간 맵핑 책임을 갖는 모듈 생성 및 구현 - `EntityUIMapper`
- [x] DesignSystem에 대한 Reactive extension을 사용할 수 있는 모듈 구현 - `DesignSystemReactive`
- [x] Coordinator, ViewModel, ViewController deinit 로깅을 위해 Logger 모듈 의존성 추가

<br>

### 📝 부가 설명

### 작업 배경 - DesignSystemReactive
DesignSystem 모듈은 RxSwift에 대한 의존성을 갖지 않도록 했지만,  
이렇게 할 경우 DesignSystem에 정의된 Custom 뷰 컴포넌트들에 대한 Reactive 확장을 사용할 수 없다는 불편이 있었습니다.

이에 대한 해결책으로 2가지 아이디어가 있었고,
1. DesignSystem 모듈에 RxSwift 의존성 추가해버리기
2. DesignSystem 모듈에 대한 Reactive를 구현한 별도의 모듈 생성하기

1번의 경우 가장 간단하게 해결할 수 있는 방법이지만,
Reactive, Binder 등 UI와 관련된 타입 외에 RxSwift에 선언된 모든 타입들을
DesignSystem 모듈이 알게되는 것이 맞는가에 대한 의문이 있어
결국 2번 방법을 선택했습니다.

이제 DesignSystem 컴포넌트에 대한 Reactive 확장은 DesignSystemReactive 모듈에 선언하면 되며,
Presentation 모듈은 필요시 해당 모듈을 import하여 사용하면 됩니다.  

*모듈 네이밍은 `ReactiveDesignSystem`이 더 괜찮다고 생각했는데,
import될 때 알파벳 순으로 정렬하면서 DesignSystem 모듈과 나란히 있는게 좋을 것 같아 `DesignSystemReactive`로 결정했습니다 😅


### 작업 배경 - EntityUIMapper

CoreEntity 모듈은 UI 관련 의존성(Image나 Color 등)을 가져선 안되므로,  
CoreEntity의 속성에 대응되는 UI 관련 에셋을 해당 타입 내에서 직접 정의내릴 수 없습니다.
```swift
public enum StoolColor: Int, Codable, CaseIterable { // CoreEntity 타입
    case brown
    case black
    case pink
    case green
    case yellow

    public var color: UIColor { // 자신의 속성에 대한 UIColor를 직접 정의할 경우, 의존성 규칙 위반
        switch self {
        case .brown:
            return ColorAsset.pooBrown.color
        case .black:
            return ColorAsset.pooBlack.color
        case .pink:
            return ColorAsset.pooPink.color
        case .green:
            return ColorAsset.pooGreen.color
        case .yellow:
            return ColorAsset.pooYellow.color
        }
    }
}
```

이 Entity를 전달받는 ViewModel 또한 마찬가지로 UIKit 의존성이 있어선 안됩니다.
따라서 ViewController에서 해당 작업(CoreEntity-UI 맵핑 작업)에 대한 코드를 작성해야 했는데,
이러한 코드가 각 ViewController마다 존재하게 될 경우 코드 중복은 물론 유지보수에 심각한 문제가 생깁니다.

이에 대한 해결로 "CoreEntity와 UI 에셋을 맵핑하는 공통의 모듈을 만들자"라는 결론이 나왔고,
해당 역할을 수행하는 별도의 모듈을 만들어 모든 ViewController(Presentation 모듈)에서
필요시 간편하게 Entity에 대응되는 UI를 맵핑하고 적용할 수 있게되었습니다.


---

- ViewController에 대한 deinit 로깅은 LifePoopViewController에 구현했습니다.
- Coordinator, ViewModel에 deinit 로깅 코드를 추가하는건 충돌을 고려해서 develop 머지 후에 작업하겠습니다.
