### PR TITLE
SignUp 화면, NicknameUseCase 로직 및 NicknameInput Entity 코드 개선

### DIFF
--- a/Projects/Core/CoreEntity/Sources/BirthdayTextInput.swift
+++ b/Projects/Core/CoreEntity/Sources/BirthdayTextInput.swift
@@ -1,0 +1,27 @@
+//
+//  BirthdayTextInput.swift
+//  CoreEntity
+//
+//  Created by 김상혁 on 2023/06/16.
+//  Copyright © 2023 Lifepoo. All rights reserved.
+//
+
+import Foundation
+
+public struct BirthdayTextInput {
+    
+    public enum Status {
+        case possible
+        case defaultWarning
+        case impossible
+        case `default`
+    }
+    
+    public let isValid: Bool
+    public let status: Status
+    
+    public init(isValid: Bool, status: Status) {
+        self.isValid = isValid
+        self.status = status
+    }
+}

--- a/Projects/Core/CoreEntity/Sources/GenderType.swift
+++ b/Projects/Core/CoreEntity/Sources/GenderType.swift
@@ -10,14 +10,14 @@ import Foundation
 
 public enum GenderType: Int, CaseIterable, CustomStringConvertible {
     
-    case male
     case female
+    case male
     case etc
     
     public var description: String {
         switch self {
-        case .male: return "남성"
         case .female: return "여성"
+        case .male: return "남성"
         case .etc: return "기타"
         }
     }    

--- a/Projects/Core/CoreEntity/Sources/NicknameTextInput.swift
+++ b/Projects/Core/CoreEntity/Sources/NicknameTextInput.swift
@@ -1,5 +1,5 @@
 //
-//  NicknameInput.swift
+//  NicknameTextInput.swift
 //  CoreEntity
 //
 //  Created by Lee, Joon Woo on 2023/06/07.
@@ -8,12 +8,13 @@
 
 import Foundation
 
-public struct NicknameInputStatus {
+public struct NicknameTextInput {
     
     public enum Status {
-        case possible(description: String)
-        case impossible(description: String)
-        case none(description: String)
+        case possible
+        case defaultWarning
+        case impossible
+        case `default`
     }
     
     public let isValid: Bool

--- a/Projects/DesignSystem/Sources/Component/ConditionalTextField/ConditionalTextField.swift
+++ b/Projects/DesignSystem/Sources/Component/ConditionalTextField/ConditionalTextField.swift
@@ -25,6 +25,7 @@ final public class ConditionalTextField: UIControl {
         textField.addTarget(self, action: #selector(textFieldDidChange), for: .editingChanged)
         textField.delegate = self
         textField.clearButtonMode = .whileEditing
+        textField.inputAccessoryView = toolbar
         return textField
     }()
     
@@ -40,6 +41,25 @@ final public class ConditionalTextField: UIControl {
         label.font = UIFont.systemFont(ofSize: 14)
         label.sizeToFit()
         return label
+    }()
+    
+    private lazy var toolbar: UIToolbar = {
+        let toolbar = UIToolbar(frame: CGRect(x: .zero, y: .zero, width: UIScreen.main.bounds.width, height: 44))
+        toolbar.backgroundColor = .systemBackground
+        toolbar.sizeToFit()
+        let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+        toolbar.setItems([flexibleSpace, doneBarButtonItem], animated: true)
+        return toolbar
+    }()
+    
+    private lazy var doneBarButtonItem: UIBarButtonItem = {
+        let barButtonItem = UIBarButtonItem(
+            title: "완료",
+            style: .done,
+            target: nil,
+            action: #selector(tapDoneBarButton)
+        )
+        return barButtonItem
     }()
     
     public enum TextFieldStatus {
@@ -93,8 +113,9 @@ final public class ConditionalTextField: UIControl {
         return CGSize(width: bounds.width, height: totalHeight)
     }
     
-    public init() {
+    public init(keyboardType: UIKeyboardType = .default) {
         super.init(frame: .zero)
+        textField.keyboardType = keyboardType
         configureUI()
     }
     
@@ -110,6 +131,10 @@ final public class ConditionalTextField: UIControl {
     
     @objc private func textFieldDidChange(_ textField: UITextField) {
         text = textField.text
+    }
+    
+    @objc private func tapDoneBarButton() {
+        textField.resignFirstResponder()
     }
     
     private func configureUI() {
@@ -156,6 +181,7 @@ extension ConditionalTextField: UITextFieldDelegate {
     
     public func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         textField.resignFirstResponder()
+        sendActions(for: .editingDidEndOnExit)
         return true
     }
 }

--- a/Projects/EntityUIMapper/Sources/BirthdayTextInput+descriptionText.swift
+++ b/Projects/EntityUIMapper/Sources/BirthdayTextInput+descriptionText.swift
@@ -1,0 +1,27 @@
+//
+//  BirthdayTextInput+descriptionText.swift
+//  EntityUIMapper
+//
+//  Created by 김상혁 on 2023/06/16.
+//  Copyright © 2023 Lifepoo. All rights reserved.
+//
+
+import Foundation
+
+import CoreEntity
+import DesignSystem
+
+public extension BirthdayTextInput.Status {
+    var descriptionText: ConditionalTextField.TextFieldStatus {
+        switch self {
+        case .`default`:
+            return ConditionalTextField.TextFieldStatus.none(text: "생년월일 6자를 입력해주세요.")
+        case .defaultWarning:
+            return ConditionalTextField.TextFieldStatus.impossible(text: "생년월일 6자를 입력해주세요.")
+        case .possible:
+            return ConditionalTextField.TextFieldStatus.possible(text: "유효한 생년월일 형식입니다.")
+        case .impossible:
+            return ConditionalTextField.TextFieldStatus.impossible(text: "유효하지 않은 생년월일 형식입니다.")
+        }
+    }
+}

--- a/Projects/EntityUIMapper/Sources/NicknameInput+descriptionText.swift
+++ b/Projects/EntityUIMapper/Sources/NicknameInput+descriptionText.swift
@@ -1,0 +1,27 @@
+//
+//  NicknameTextInput+descriptionText.swift
+//  EntityUIMapper
+//
+//  Created by 김상혁 on 2023/06/16.
+//  Copyright © 2023 Lifepoo. All rights reserved.
+//
+
+import Foundation
+
+import CoreEntity
+import DesignSystem
+
+public extension NicknameTextInput.Status {
+    var descriptionText: ConditionalTextField.TextFieldStatus {
+        switch self {
+        case .`default`:
+            return ConditionalTextField.TextFieldStatus.none(text: "2~5자로 한글, 영문, 숫자를 사용할 수 있습니다.")
+        case .defaultWarning:
+            return ConditionalTextField.TextFieldStatus.impossible(text: "2~5자로 한글, 영문, 숫자를 사용할 수 있습니다.")
+        case .possible:
+            return ConditionalTextField.TextFieldStatus.possible(text: "사용 가능한 닉네임입니다.")
+        case .impossible:
+            return ConditionalTextField.TextFieldStatus.impossible(text: "사용 불가능한 닉네임입니다.")
+        }
+    }
+}

--- a/Projects/Features/FeatureFriendList/FeatureFriendListPresentation/Project.swift
+++ b/Projects/Features/FeatureFriendList/FeatureFriendListPresentation/Project.swift
@@ -17,6 +17,8 @@ let project = Project.makeModule(
     dependencies: [
         .Project.module(.Core(.CoreEntity)).dependency,
         .Project.module(.DesignSystem).dependency,
+        .Project.module(.DesignSystemReactive).dependency,
+        .Project.module(.EntityUIMapper).dependency,
         .Project.module(.Logger).dependency,
         .Project.module(.Utils).dependency,
         .Project.module(.Features(.FriendList, .UseCase)).dependency,

--- a/Projects/Features/FeatureHome/FeatureHomePresentation/Project.swift
+++ b/Projects/Features/FeatureHome/FeatureHomePresentation/Project.swift
@@ -17,6 +17,8 @@ let project = Project.makeModule(
     dependencies: [
         .Project.module(.Core(.CoreEntity)).dependency,
         .Project.module(.DesignSystem).dependency,
+        .Project.module(.DesignSystemReactive).dependency,
+        .Project.module(.EntityUIMapper).dependency,
         .Project.module(.Logger).dependency,
         .Project.module(.Utils).dependency,
         .Project.module(.Features(.Home, .UseCase)).dependency,

--- a/Projects/Features/FeatureLogin/FeatureLoginPresentation/Project.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginPresentation/Project.swift
@@ -16,6 +16,8 @@ let project = Project.makeModule(
     ],
     dependencies: [
         .Project.module(.Core(.CoreEntity)).dependency,
+        .Project.module(.DesignSystemReactive).dependency,
+        .Project.module(.EntityUIMapper).dependency,
         .Project.module(.DesignSystem).dependency,
         .Project.module(.Logger).dependency,
         .Project.module(.Utils).dependency,

--- a/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/SignupScene/SignupViewController.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/SignupScene/SignupViewController.swift
@@ -37,7 +37,7 @@ public final class SignupViewController: LifePoopViewController, ViewType {
     }()
     
     private let birthdayTextField: ConditionalTextField = {
-        let textField = ConditionalTextField()
+        let textField = ConditionalTextField(keyboardType: .numberPad)
         textField.title = "생년월일을 입력해주세요"
         textField.placeholder = "예) 990101"
         return textField
@@ -154,6 +154,13 @@ public final class SignupViewController: LifePoopViewController, ViewType {
         birthdayTextField.rx.text
             .skip(1)
             .bind(to: input.didEnterBirthday)
+            .disposed(by: disposeBag)
+        
+        nicknameTextField.rx.controlEvent(.editingDidEndOnExit)
+            .withUnretained(self)
+            .bind { `self`, _ in
+                self.birthdayTextField.becomeFirstResponder()
+            }
             .disposed(by: disposeBag)
         
         selectAllConditionView.rx.check

--- a/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/SignupScene/SignupViewController.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/SignupScene/SignupViewController.swift
@@ -15,6 +15,7 @@ import SnapKit
 import CoreEntity
 import DesignSystem
 import DesignSystemReactive
+import EntityUIMapper
 import Utils
 
 public final class SignupViewController: LifePoopViewController, ViewType {
@@ -32,7 +33,6 @@ public final class SignupViewController: LifePoopViewController, ViewType {
         let textField = ConditionalTextField()
         textField.title = "닉네임을 설정해주세요"
         textField.placeholder = "닉네임 입력하기"
-        textField.status = .none(text: "2~5자로 한글, 영문, 숫자를 사용할 수 있습니다.")
         return textField
     }()
     
@@ -40,7 +40,6 @@ public final class SignupViewController: LifePoopViewController, ViewType {
         let textField = ConditionalTextField()
         textField.title = "생년월일을 입력해주세요"
         textField.placeholder = "예) 990101"
-        textField.status = .none(text: "")
         return textField
     }()
     
@@ -174,30 +173,12 @@ public final class SignupViewController: LifePoopViewController, ViewType {
         let output = viewModel.output
         
         output.nicknameTextFieldStatus
-            .map {
-                switch $0 {
-                case .none(let text):
-                    return ConditionalTextField.TextFieldStatus.none(text: text)
-                case .possible(let text):
-                    return ConditionalTextField.TextFieldStatus.possible(text: text)
-                case .impossible(let text):
-                    return ConditionalTextField.TextFieldStatus.impossible(text: text)
-                }
-            }
+            .map { $0.descriptionText }
             .bind(to: nicknameTextField.rx.status)
             .disposed(by: disposeBag)
         
         output.birthdayTextFieldStatus
-            .map {
-                switch $0 {
-                case .none(let text):
-                    return ConditionalTextField.TextFieldStatus.none(text: text)
-                case .possible(let text):
-                    return ConditionalTextField.TextFieldStatus.possible(text: text)
-                case .impossible(let text):
-                    return ConditionalTextField.TextFieldStatus.impossible(text: text)
-                }
-            }
+            .map { $0.descriptionText }
             .bind(to: birthdayTextField.rx.status)
             .disposed(by: disposeBag)
         

--- a/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/SignupScene/SignupViewModel.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/SignupScene/SignupViewModel.swift
@@ -54,10 +54,8 @@ public final class SignupViewModel: ViewModelType {
     
     public struct Output {
         let conditionSelectionCellViewModels = BehaviorRelay<[ConditionSelectionCellViewModel]>(value: [])
-        let nicknameTextFieldStatus = BehaviorRelay<NicknameInputStatus.Status>(value:
-                .none(description: "2~5자로 한글, 영문, 숫자를 사용할 수 있습니다.")
-        )
-        let birthdayTextFieldStatus = BehaviorRelay<NicknameInputStatus.Status>(value: .none(description: ""))
+        let nicknameTextFieldStatus = BehaviorRelay<NicknameTextInput.Status>(value: .`default`)
+        let birthdayTextFieldStatus = BehaviorRelay<BirthdayTextInput.Status>(value: .`default`)
         let shouldCheckCondition = PublishRelay<Int>()
         let selectAllOptionConfig = Observable.just(AgreementCondition(
             descriptionText: "전체동의",

--- a/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/Interface/SignupUseCase.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/Interface/SignupUseCase.swift
@@ -13,7 +13,7 @@ import CoreEntity
 public protocol SignupUseCase {
     
     func fetchSelectableConditions() -> Observable<[AgreementCondition]>
-    func isNicknameInputValid(_ input: String) -> Observable<NicknameInputStatus>
-    func isBirthdayInputValid(_ input: String) -> Observable<NicknameInputStatus>
+    func isNicknameInputValid(_ input: String) -> Observable<NicknameTextInput>
+    func isBirthdayInputValid(_ input: String) -> Observable<BirthdayTextInput>
     func isAllEsssentialConditionsSelected(_ selectedConditions: Set<AgreementCondition>) -> Observable<Bool>
 }

--- a/Projects/Features/FeatureReport/FeatureReportPresentation/Project.swift
+++ b/Projects/Features/FeatureReport/FeatureReportPresentation/Project.swift
@@ -17,6 +17,8 @@ let project = Project.makeModule(
     dependencies: [
         .Project.module(.Core(.CoreEntity)).dependency,
         .Project.module(.DesignSystem).dependency,
+        .Project.module(.DesignSystemReactive).dependency,
+        .Project.module(.EntityUIMapper).dependency,
         .Project.module(.Logger).dependency,
         .Project.module(.Utils).dependency,
         .Project.module(.Features(.Report, .UseCase)).dependency,

--- a/Projects/Features/FeatureStoolLog/FeatureStoolLogPresentation/Project.swift
+++ b/Projects/Features/FeatureStoolLog/FeatureStoolLogPresentation/Project.swift
@@ -17,6 +17,8 @@ let project = Project.makeModule(
     dependencies: [
         .Project.module(.Core(.CoreEntity)).dependency,
         .Project.module(.DesignSystem).dependency,
+        .Project.module(.DesignSystemReactive).dependency,
+        .Project.module(.EntityUIMapper).dependency,
         .Project.module(.Logger).dependency,
         .Project.module(.Utils).dependency,
         .Project.module(.Features(.StoolLog, .UseCase)).dependency,

--- a/Projects/Shared/SharedUseCase/Sources/DefaultNicknameUseCase.swift
+++ b/Projects/Shared/SharedUseCase/Sources/DefaultNicknameUseCase.swift
@@ -34,7 +34,7 @@ public final class DefaultNicknameUseCase: NicknameUseCase {
             .logErrorIfDetected(category: .userDefaults)
     }
     
-    public func checkNicknameValidation(for input: String) -> Observable<NicknameInputStatus> {
+    public func checkNicknameValidation(for input: String) -> Observable<NicknameTextInput> {
         Observable.zip(
             hasAnyBlank(input: input),
             didExceedLimit(input: input),
@@ -44,10 +44,17 @@ public final class DefaultNicknameUseCase: NicknameUseCase {
         .map {
             let isValid =  !($0 || $1 || $2 || $3)
             let isEmpty = $3
-            let status: NicknameInputStatus.Status = isEmpty  ? .impossible(description: "닉네임을 입력해주세요")
-                                                     :isValid ? .possible(description: "사용 가능한 닉네임이에요")
-                                                              : .impossible(description: "사용 불가능한 닉네임이에요")
-            return NicknameInputStatus(isValid: isValid, status: status)
+            
+            if isEmpty {
+                return NicknameTextInput(isValid: isValid, status: .defaultWarning)
+            }
+            
+            switch isValid {
+            case true:
+                return NicknameTextInput(isValid: isValid, status: .possible)
+            case false:
+                return NicknameTextInput(isValid: isValid, status: .impossible)
+            }
         }
     }
 }

--- a/Projects/Shared/SharedUseCase/Sources/Interface/NicknameUseCase.swift
+++ b/Projects/Shared/SharedUseCase/Sources/Interface/NicknameUseCase.swift
@@ -15,5 +15,5 @@ import RxSwift
 public protocol NicknameUseCase {
     var nickname: Observable<String?> { get }
     func updateNickname(to newNickname: String) -> Completable
-    func checkNicknameValidation(for input: String) -> Observable<NicknameInputStatus>
+    func checkNicknameValidation(for input: String) -> Observable<NicknameTextInput>
 }


### PR DESCRIPTION
### 🔖 관련 이슈
- #67 

<br> 

### ⚒️ 작업 내역

- [x] SignUp 화면을 피그마 요구사항에 맞게 수정합니다.
- [x] TextField에 완료 버튼, 리턴시 다음 TextField를 입력할 수 있는 사용자 편의성을 제공합니다.
- [x] 생년월일 TextField의 경우 숫자패드 키보드가 나타나도록 변경합니다.
- [x] 생년월일 유효성 검사 로직을 더 정확하게 개선합니다.
- [x] UseCase 로직 코드를 개선합니다.

<br>

### 📝 부가 설명

#### 사용자 편의성 및 검증 로직 강화, Entity와 UseCase 코드 개선 작업을 진행했습니다.
- 기존에 작성된 코드로는 생년월일을 '숫자 6자'로만 입력하면 어떤 형태든 validation을 통과하는 구조라서,
  실제 생년월일 형식에 맞는 숫자인지 검증하는 로직까지 추가 구현했습니다. (윤년도 고려)
- 생년월일 입력시 나타나는 키보드를 숫자패드만 있는 키보드로 변경했습니다.
- 닉네임 입력 후 리턴 버튼을 누르면 생년월일 입력란이 firstResponder가 되도록 변경했습니다.
- 기존에 중첩된 삼항 연산자가 있던 UseCase 로직을 각각 분기문으로 분리했습니다.

<br> 

### 📑 첨부 자료

https://github.com/LifePoop/LifePoop_iOS/assets/57667738/4b859441-d0e9-464e-bb92-fb86f567e25f

