### PR TITLE
프로필 캐릭터를 수정해도 '수정 완료' 버튼이 활성화되지 않는 문제 해결

### DIFF
--- a/Projects/Features/FeatureSetting/FeatureSettingPresentation/Sources/ProfileEdit/ProfileEditViewModel.swift
+++ b/Projects/Features/FeatureSetting/FeatureSettingPresentation/Sources/ProfileEdit/ProfileEditViewModel.swift
@@ -219,7 +219,7 @@ public final class ProfileEditViewModel: ViewModelType {
             .disposed(by: disposeBag)
         
         let isNicknameValid = nicknameValidation
-            .startWith(.default)
+            .startWith(.possible)
             .map { $0 == .possible }
             .distinctUntilChanged()
             .share()


### PR DESCRIPTION

### 🔖 관련 이슈
- #71 

<br> 

### ⚒️ 작업 내역

- [x] ProfileEdit 뷰에서 프로필 캐릭터를 수정해도 '수정 완료' 버튼이 활성화되지 않는 문제 해결

<br>

### 📝 부가 설명

닉네임 유효성과 프로필 캐릭터의 변경 여부를 검사해서 수정 완료 버튼의 enable 여부가 결정되는데,
NicknameTextInput.Status가 변경되면서 문제가 발생했습니다.
(ProfileCharacter 관련 로직에는 문제가 없었음)

isNicknameValid의 startWith 스트림을 '.default'에서 '.possible'로 수정하여 해결했습니다.

<br> 

### 📑 첨부 자료

|작업 이전|작업 이후|
|-----|-----|
|![CleanShot 2023-06-17 at 22 00 56](https://github.com/LifePoop/LifePoop_iOS/assets/57667738/28a5be19-0b33-4c1c-bac1-6b2d2224d72c)|![CleanShot 2023-06-17 at 22 01 42](https://github.com/LifePoop/LifePoop_iOS/assets/57667738/f470cfea-2c1b-4b25-9a95-91d71b483e25)|



