### PR TITLE
초대코드 공유 및 입력 화면 좀 더 자연스럽게 닫히도록 수정

### DIFF
--- a/Projects/DesignSystem/Sources/Component/UIView/LifePoopAlertView.swift
+++ b/Projects/DesignSystem/Sources/Component/UIView/LifePoopAlertView.swift
@@ -98,6 +98,16 @@ public class LifePoopAlertView: UIControl {
         fadeOut(completion: removeViews)
     }
     
+    public func dismiss(_ completion: (() -> Void)? = nil) {
+        let removeViews: (Bool) -> Void = { _ in
+            self.backgroundView.removeFromSuperview()
+            self.removeFromSuperview()
+            completion?()
+        }
+        
+        fadeOut(completion: removeViews)
+    }
+    
     public func moveUp(to value: CGFloat) {
         frame.origin.y -= value
         UIView.animate(withDuration: 0.3) { self.layoutIfNeeded() }

--- a/Projects/Features/FeatureFriendList/FeatureFriendListPresentation/Sources/InvitationCodeViewController/InvitationCodeViewController.swift
+++ b/Projects/Features/FeatureFriendList/FeatureFriendListPresentation/Sources/InvitationCodeViewController/InvitationCodeViewController.swift
@@ -58,7 +58,7 @@ public final class InvitationCodeViewController: LifePoopViewController, ViewTyp
         let output = viewModel.output
         
         output.shouldDismissAlertView
-            .bind(onNext: alertView.dismiss)
+            .bind(onNext: dismissEnteringCodePopup)
             .disposed(by: disposeBag)
         
         output.shouldShowInvitationCodePopup
@@ -85,6 +85,12 @@ private extension InvitationCodeViewController {
     func showEnteringCodePopup() {
         alertView.show(in: view)
         alertView.becomeFirstResponder()
+    }
+    
+    func dismissEnteringCodePopup() {
+        alertView.dismiss { [weak self] in
+            self?.viewModel?.input.didCloseInvitationCodePopup.accept(())
+        }
     }
     
     func showSharingPopup() {

--- a/Projects/Features/FeatureFriendList/FeatureFriendListPresentation/Sources/InvitationCodeViewController/InvitationCodeViewController.swift
+++ b/Projects/Features/FeatureFriendList/FeatureFriendListPresentation/Sources/InvitationCodeViewController/InvitationCodeViewController.swift
@@ -102,19 +102,30 @@ private extension InvitationCodeViewController {
         ]
         
         activityViewController.completionWithItemsHandler = { [weak self] activity, success, _, error in
-            guard success else {
+            if let error = error {
                 self?.viewModel?.input.didCloseSharingPopup.accept(.failure(error: error))
                 return
             }
-    
+            
+            // MARK: 사용자가 동작을 취소한 경우에는 success = fail, presentedViewController != nil 인 상태
+            guard success else {
+                self?.dismissViewControllerIfNeeded()
+                return
+            }
             if activity == .copyToPasteboard {
                 self?.viewModel?.input.didCloseSharingPopup.accept(.success(activity: .copying))
             } else {
                 self?.viewModel?.input.didCloseSharingPopup.accept(.success(activity: .sharing))
             }
-    }
+        }
         
-        self.present(activityViewController, animated: true)
+        present(activityViewController, animated: true)
+    }
+    
+    func dismissViewControllerIfNeeded() {
+        if presentedViewController != nil { return }
+        
+        viewModel?.input.didCloseSharingPopup.accept(nil)
     }
 }
 

--- a/Projects/Features/FeatureFriendList/FeatureFriendListPresentation/Sources/InvitationCodeViewController/InvitationCodeViewModel.swift
+++ b/Projects/Features/FeatureFriendList/FeatureFriendListPresentation/Sources/InvitationCodeViewController/InvitationCodeViewModel.swift
@@ -34,7 +34,7 @@ public final class InvitationCodeViewModel: ViewModelType {
             case .success(let activity):
                 return activity == .copying ? "초대 코드 복사 완료" :
                                               "초대 코드 공유 완료"
-            case .failure(_):
+            case .failure:
                 return "초대 코드 공유 실패"
             }
         }
@@ -46,6 +46,7 @@ public final class InvitationCodeViewModel: ViewModelType {
         let didTapConfirmButton = PublishRelay<Void>()
         let didTapCancelButton = PublishRelay<Void>()
         let didCloseSharingPopup = PublishRelay<SharingResult?>()
+        let didCloseInvitationCodePopup = PublishRelay<Void>()
     }
     
     public struct Output {
@@ -92,15 +93,20 @@ public final class InvitationCodeViewModel: ViewModelType {
             .disposed(by: disposeBag)
         
         input.didTapCancelButton
-            .bind(onNext: { _ in
-                coordinator?.coordinate(by: .shouldDismissInvitationCodePopup)
-            })
+            .bind(to: output.shouldDismissAlertView)
             .disposed(by: disposeBag)
 
         input.didTapConfirmButton
             .withLatestFrom(input.didEnterInvitationCode)
-            .bind(onNext: { invitationCode in
+            .do(onNext: { invitationCode in
                 Logger.log(message: "초대코드 입력 확인 : \(invitationCode)", category: .default, type: .debug)
+            })
+            .map { _ in Void() }
+            .bind(to: output.shouldDismissAlertView)
+            .disposed(by: disposeBag)
+
+        input.didCloseInvitationCodePopup
+            .bind(onNext: { _ in
                 coordinator?.coordinate(by: .shouldDismissInvitationCodePopup)
             })
             .disposed(by: disposeBag)


### PR DESCRIPTION
### 🔖 관련 이슈
- #78 

<br> 

### ⚒️ 작업 내역
- [x] 공유 화면에서 아무동작 안했을 때 팝업 그대로 나타나도록 처리
- [x] 입력 화면에서 취소 혹은 확인 버튼 터치했을 때 좀 더 자연스게 화면 사라지도록 처리

<br>

### 💻 리뷰어 가이드
> 아래와 같은 순서로 동작하면 됩니다.
### 공유팝업 띄워진 상태에서
- Copy 터치 > 팝업 닫힘 > '초대코드 복사 완료' 토스트 출력 확인
- Messages 터치 > 메시지 앱 확인 > 메시지 전송 > 팝업 포함 모든 화면 닫힌 것 확인 > '초대코드 공유 완료' 토스트 출력 확인
- Messages 터치 > 메시지 앱 확인 > 취소 터치 > 공유 팝업 그대로 노출된 것 확인
- 팝업 닫기 버튼 터치 혹은 강제로 끌어내려서 닫기 > 토스트 메시지 출력 안된 것 확인

### 입력팝업 띄워진 상태에서
- 취소 버튼 터치 > 팝업이 사라지면서 키보드 내려가는 동작 확인 > 최종적으로 초대코드 뷰컨트롤러 사라진 것 확인
- 입력 완료 버튼 터치 > 팝업이 사라지면서 키보드 내려가는 동작 확인 > 최종적으로 초대코드 뷰컨트롤러 사라진 것 확인

<br>