### PR TITLE
프로필 설정 화면에서 존재하는 UI와 로직의 문제 해결

### DIFF
--- a/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/SignupScene/SignupViewModel.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/SignupScene/SignupViewModel.swift
@@ -78,6 +78,9 @@ public final class SignupViewModel: ViewModelType {
     @Inject(LoginDIContainer.shared) private var loginUseCase: LoginUseCase
     @Inject(LoginDIContainer.shared) private var signupUseCase: SignupUseCase
     @Inject(SharedDIContainer.shared) private var bundleResourceUseCase: BundleResourceUseCase
+    
+    // FIXME: 디폴트 캐릭터 지정하기 위한 UseCase - 서버에서 디폴트 캐릭터 설정된 상태로 받아올 경우 삭제
+    @Inject(SharedDIContainer.shared) private var profileCharacterUseCase: ProfileCharacterUseCase
 
     private weak var coordinator: LoginCoordinator?
     private let authInfo: UserAuthInfoEntity
@@ -91,6 +94,15 @@ public final class SignupViewModel: ViewModelType {
     
     private func bind() {
         guard let coordinator = self.coordinator else { return }
+        
+        // FIXME: 디폴트 캐릭터 지정하는 코드 - 서버에서 디폴트 캐릭터 설정된 상태로 받아올 경우 삭제
+        input.didTapNextButton
+            .withUnretained(self)
+            .flatMapCompletableMaterialized { `self`, _ in
+                self.profileCharacterUseCase.updateProfileCharacter(to: ProfileCharacter(color: .brown, shape: .good))
+            }
+            .bind { _ in }
+            .disposed(by: disposeBag)
         
         signupUseCase.fetchSelectableConditions()
             .withUnretained(self)

--- a/Projects/Features/FeatureSetting/FeatureSettingPresentation/Sources/ProfileEdit/ProfileCharacterEditViewController.swift
+++ b/Projects/Features/FeatureSetting/FeatureSettingPresentation/Sources/ProfileEdit/ProfileCharacterEditViewController.swift
@@ -120,12 +120,12 @@ public final class ProfileCharacterEditViewController: LifePoopViewController, V
         view.addSubview(shapeSelectionStackView)
         
         titleLabel.snp.makeConstraints { make in
-            make.top.equalTo(view.safeAreaLayoutGuide).offset(-6)
+            make.top.equalTo(view.safeAreaLayoutGuide).offset(6)
             make.centerX.equalToSuperview()
         }
         
         colorTitleLabel.snp.makeConstraints { make in
-            make.centerY.equalToSuperview().multipliedBy(0.56)
+            make.centerY.equalToSuperview().multipliedBy(0.62)
             make.leading.equalTo(view.safeAreaLayoutGuide).offset(24)
         }
         
@@ -136,7 +136,7 @@ public final class ProfileCharacterEditViewController: LifePoopViewController, V
         }
         
         shapeTitleLabel.snp.makeConstraints { make in
-            make.centerY.equalToSuperview().multipliedBy(1.24)
+            make.centerY.equalToSuperview().multipliedBy(1.30)
             make.leading.equalTo(view.safeAreaLayoutGuide).offset(24)
         }
         

--- a/Projects/Features/FeatureSetting/FeatureSettingPresentation/Sources/ProfileEdit/ProfileEditViewModel.swift
+++ b/Projects/Features/FeatureSetting/FeatureSettingPresentation/Sources/ProfileEdit/ProfileEditViewModel.swift
@@ -82,23 +82,6 @@ public final class ProfileEditViewModel: ViewModelType {
             .bind(to: output.setUserNickname)
             .disposed(by: disposeBag)
         
-        // FIXME: 서버에서 유저 생성시 기본 캐릭터 설정해줄 경우 불필요함 - 삭제하기
-        /// 아직 프로필 캐릭터를 설정하지 않은 유저에 대해 디폴트 캐릭터 설정하는 코드
-        /// - 이렇게 '프로필 정보 수정 화면에 진입할 때' nil인지 확인해서 디폴트 캐릭터를 설정할 것인지,
-        /// - 아니면 '초기에 사용자가 계정을 생성할 때' 디폴트 캐릭터를 설정해 줄 것인지는 추후 결정
-        // input.viewDidLoad
-        //     .withLatestFrom(state.profileCharacter)
-        //     .filter { $0 == nil }
-        //     .map { _ in ProfileCharacter(color: .brown, shape: .good) }
-        //     .withUnretained(self)
-        //     .flatMapCompletableMaterialized { `self`, profileCharacter in
-        //         self.profileCharacterUseCase.updateProfileCharacter(to: profileCharacter)
-        //     }
-        //     .filter { $0.isCompleted }
-        //     .map { _ in ProfileCharacter(color: .brown, shape: .good) }
-        //     .bind(to: state.profileCharacter)
-        //     .disposed(by: disposeBag)
-        
         input.nicknameDidChange
             .skip(1)
             .bind(to: state.changedUserNickname)

--- a/Projects/Shared/SharedUseCase/Sources/DefaultNicknameUseCase.swift
+++ b/Projects/Shared/SharedUseCase/Sources/DefaultNicknameUseCase.swift
@@ -30,7 +30,7 @@ public final class DefaultNicknameUseCase: NicknameUseCase {
     
     public func updateNickname(to newNickname: String) -> Completable {
         return userDefaultsRepository
-            .updateValue(for: .isAutoLoginActivated, with: newNickname)
+            .updateValue(for: .userNickname, with: newNickname)
             .logErrorIfDetected(category: .userDefaults)
     }
     


### PR DESCRIPTION
### 🔖 관련 이슈
- #89 

<br> 

### ⚒️ 작업 내역

- [x] 닉네임을 수정한 뒤, 수정 완료를 눌러도 변경된 닉네임 저장되지 않는 문제 해결
- [x] 프로필 캐릭터 화면 UI의 레이아웃이 올바르지 않은 문제 해결
- [x] 테스트 플라이트에서 프로필 캐릭터가 설정되도록 변경
        (서버 구현시까지 임시로 동작하는 코드, 서버 로직 완성되면 삭제)

<br>

### 📝 부가 설명

테스트플라이트에서 프로필 캐릭터가 nil로 설정되어있어서, 프로필 정보 수정 로직을 사용해 볼 수 없었던 것을 해결하기 위해
SignUp 화면이 종료되고 다음 화면으로 넘어가기 전에 기본 캐릭터를 설정해주는 코드를 추가했습니다.
이후 서버 로직에 따라(서버에서 사용자 기본 캐릭터를 설정해서 줄 경우) 해당 코드는 삭제되어야 할 수 있어서,
해당 내용에 대한 주석을 달아두었습니다.

|작업 이전|작업 이후|
|-----|-----|
|![IMG_9967](https://github.com/LifePoop/LifePoop_iOS/assets/57667738/67296e95-944f-48ed-ae26-980528aec715)|![IMG_9968](https://github.com/LifePoop/LifePoop_iOS/assets/57667738/6b7a1916-67ba-4a68-867d-50d59226561a)|


