### PR TITLE
Project 파일의 의존성 선언 순서 정렬을 위한 git hook 설정

### DIFF
--- a/Projects/Features/FeatureLogin/FeatureLoginUseCase/Project.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginUseCase/Project.swift
@@ -15,9 +15,9 @@ let project = Project.makeModule(
     dependencies: [
         .Project.module(.Core(.CoreEntity)).dependency,
         .Project.module(.Features(.Login, .DIContainer)).dependency,
+        .Project.module(.Logger).dependency,
         .Project.module(.Shared(.SharedDIContainer)).dependency,
         .Project.module(.Shared(.SharedUseCase)).dependency,
-        .Project.module(.Logger).dependency,
         .Project.module(.Utils).dependency,
         .SPM.RxSwift.dependency
     ]

--- a/Projects/Features/FeatureReport/FeatureReportCoordinator/Project.swift
+++ b/Projects/Features/FeatureReport/FeatureReportCoordinator/Project.swift
@@ -13,9 +13,9 @@ let project = Project.makeModule(
     product: .staticFramework,
     packages: [],
     dependencies: [
-        .Project.module(.Logger).dependency,
-        .Project.module(.Features(.Report, .Presentation)).dependency,
         .Project.module(.Features(.Report, .CoordinatorInterface)).dependency,
+        .Project.module(.Features(.Report, .Presentation)).dependency,
+        .Project.module(.Logger).dependency,
         .Project.module(.Utils).dependency,
     ],
     hasTests: false

--- a/common-hooks/pre-commit
+++ b/common-hooks/pre-commit
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+FILES_PATTERN="Project.swift"
+EXIT_CODE=0
+
+for FILE in $(find . -name "$FILES_PATTERN")
+do
+    DEPENDENCIES=$(grep -o '\..*\.dependency' $FILE)
+    SORTED_DEPENDENCIES=$(echo "$DEPENDENCIES" | sort)
+
+    if [ "$DEPENDENCIES" != "$SORTED_DEPENDENCIES" ]
+    then
+        echo "Dependencies in $FILE are not sorted"
+        EXIT_CODE=1
+    fi
+done
+
+exit $EXIT_CODE


### PR DESCRIPTION
### 🔖 관련 이슈
- #92 

<br> 

### ⚒️ 작업 내역

- [x] 프로젝트에서 공통으로 사용할 common-hooks 디렉토리 생성
- [x] common-hooks 디렉토리 경로에 pre-commit 쉘스크립트 작성

<br>

### 💻 리뷰어 가이드

!! `common-hooks` 디렉토리 경로를 공통 hook으로 지정하는 작업이 필요합니다. !!

Pull 받으신 다음, **프로젝트 루트 디렉토리 경로에서** 아래 커맨드를 입력해주세요.
```
git config core.hooksPath common-hooks
```

그러면 제가 쉘스크립트를 작성해둔 `common-hooks` 디렉토리가 git이 관리하는 hook으로 지정됩니다.

<br>

### 📝 부가 설명

커밋 되기 전에(pre-commit) 프로젝트 경로에 존재하는 모든 `Project.swift` 파일을 찾고,
해당 파일 내에서 정렬되지 않은 의존성 모듈을 찾는 작업이 실행됩니다.

의존성 모듈을 찾는 패턴은 `.dependency`로 끝나는 패턴을 기준으로 문장을 찾아내 정렬하는 것으로 지정했습니다.

만약 정렬되지 않은 파일이 있다면, 아래와 같은 경고가 발생하며 커밋 작업이 중단됩니다.
```
// 제가 실제로 커밋하면서 받은 에러 메세지 입니다. 이번 작업 덕분에 미처 정렬되지 않은 파일을 찾아냈네요 😅
Dependencies in ./Projects/Features/FeatureLogin/FeatureLoginUseCase/Project.swift are not sorted
Dependencies in ./Projects/Features/FeatureReport/FeatureReportCoordinator/Project.swift are not sorted
```

---

추가로 hook을 설정한 김에 더 응용해 봤는데,
`post-checkout` 쉘 스크립트를 생성하고 아래 스크립트를 작성하면
브랜치를 변경할 때 마다 `tuist generate` 커맨드를 실행해야하는 번거로움을 줄일 수 있습니다.
```
#!/bin/sh
tuist generate
```
다만 이 내용을 공통 hook에 추가하기엔 아직 협의되지 않은 내용이기도 하고,
저도 사실 브랜치 체크아웃하고 나서 해당 커맨드 입력을 수동으로 원할 때만 실행시키는걸 더 선호해서
이번 PR에 추가하진 않았습니다 ㅎㅎ

혹시나 필요하시다면, 위 쉘스크립트를 로컬 환경에 추가한 다음
원격에 push되지 않도록 해당 파일에 대한 추적을 중지하는 등의 방법을 쓰면 될 것 같습니다!