### PR TITLE
Tuist Manifests 파일 수정 및 entitlements 코드 설정

### DIFF
--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -17,5 +17,6 @@ let project = Project.makeModule(
     dependencies: TargetDependency.SPM.allDependencies + TargetDependency.Project.allDependencies,
     resources: ["Resources/**"],
     infoPlist: .file(path: "Attributes/Info.plist"),
+    entitlements: .entitlementsPath(for: .App),
     hasTests: false
 )

--- a/Tuist/ProjectDescriptionHelpers/Path+entitlements.swift
+++ b/Tuist/ProjectDescriptionHelpers/Path+entitlements.swift
@@ -1,0 +1,14 @@
+//
+//  Path+entitlements.swift
+//  ProjectDescriptionHelpers
+//
+//  Created by 김상혁 on 2023/07/05.
+//
+
+import ProjectDescription
+
+public extension Path {
+    static func entitlementsPath(for module: Modules) -> Path {
+        return Path("\(module.name).entitlements")
+    }
+}

--- a/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -28,28 +28,24 @@ public extension Project {
                 .release(name: .release)
             ], defaultSettings: .recommended)
         
-        let appTarget = Target(
+        let appTarget = makeTarget(
             name: name,
             platform: platform,
             product: product,
-            bundleId: "com.\(organizationName).\(name)",
+            bundleIdSuffix: organizationName,
             deploymentTarget: deploymentTarget,
             infoPlist: infoPlist,
             sources: sources,
             resources: resources,
-            scripts: [.SwiftLintShell],
             dependencies: dependencies
         )
         
-        let testTarget = Target(
-            name: "\(name)Tests",
+        let testTarget = makeTestTarget(
+            name: name,
             platform: platform,
-            product: .unitTests,
-            bundleId: "com.\(organizationName).\(name)Tests",
+            bundleIdSuffix: organizationName,
             deploymentTarget: deploymentTarget,
-            infoPlist: .default,
-            sources: ["Tests/**"],
-            dependencies: [.target(name: name)]
+            dependencyName: name
         )
         
         let schemes: [Scheme] = [.makeScheme(target: .debug, name: name)]
@@ -62,6 +58,50 @@ public extension Project {
             settings: settings,
             targets: targets,
             schemes: schemes
+        )
+    }
+    
+    static func makeTarget(
+        name: String,
+        platform: Platform,
+        product: Product,
+        bundleIdSuffix: String,
+        deploymentTarget: DeploymentTarget?,
+        infoPlist: InfoPlist,
+        sources: SourceFilesList,
+        resources: ResourceFileElements?,
+        dependencies: [TargetDependency]
+    ) -> Target {
+        return Target(
+            name: name,
+            platform: platform,
+            product: product,
+            bundleId: "com.\(bundleIdSuffix).\(name)",
+            deploymentTarget: deploymentTarget,
+            infoPlist: infoPlist,
+            sources: sources,
+            resources: resources,
+            scripts: [.SwiftLintShell],
+            dependencies: dependencies
+        )
+    }
+    
+    static func makeTestTarget(
+        name: String,
+        platform: Platform,
+        bundleIdSuffix: String,
+        deploymentTarget: DeploymentTarget?,
+        dependencyName: String
+    ) -> Target {
+        return Target(
+            name: "\(name)Tests",
+            platform: platform,
+            product: .unitTests,
+            bundleId: "com.\(bundleIdSuffix).\(name)Tests",
+            deploymentTarget: deploymentTarget,
+            infoPlist: .default,
+            sources: ["Tests/**"],
+            dependencies: [.target(name: dependencyName)]
         )
     }
 }

--- a/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -19,6 +19,7 @@ public extension Project {
         sources: SourceFilesList = ["Sources/**"],
         resources: ResourceFileElements? = nil,
         infoPlist: InfoPlist = .default,
+        entitlements: Path? = nil,
         hasTests: Bool = true
     ) -> Project {
         let settings: Settings = .settings(
@@ -37,6 +38,7 @@ public extension Project {
             infoPlist: infoPlist,
             sources: sources,
             resources: resources,
+            entitlements: entitlements,
             dependencies: dependencies
         )
         
@@ -70,6 +72,7 @@ public extension Project {
         infoPlist: InfoPlist,
         sources: SourceFilesList,
         resources: ResourceFileElements?,
+        entitlements: Path?,
         dependencies: [TargetDependency]
     ) -> Target {
         return Target(
@@ -81,6 +84,7 @@ public extension Project {
             infoPlist: infoPlist,
             sources: sources,
             resources: resources,
+            entitlements: entitlements,
             scripts: [.SwiftLintShell],
             dependencies: dependencies
         )


### PR DESCRIPTION
### 🔖 관련 이슈
- #96 

<br> 

### ⚒️ 작업 내역

- [x] Project+Templates.swift 코드 리팩토링
- [x] entitlements 파일 지정 추가

<br>

### 📝 부가 설명

- Project+Templates에서 모듈 Target을 생성하는 코드를 함수화했습니다.
- tuist 파일 생성시 entitlements가 지정되지 않던 문제를 해결하기 위해,
  Manifests 파일에서 entitlements의 Path를 지정할 수 있도록 변경했습니다.
- App 모듈에 대해 entitlements 경로를 지정해줬습니다.
