### PR TITLE
LifePoopButton이 비활성화 상태일 때 loading indicator와 title이 함께 나타나는 문제 해결

### DIFF
--- a/Projects/DesignSystem/Sources/Extension/String+nsAttributedString.swift
+++ b/Projects/DesignSystem/Sources/Extension/String+nsAttributedString.swift
@@ -1,0 +1,18 @@
+//
+//  String+nsAttributedString.swift
+//  DesignSystem
+//
+//  Created by 김상혁 on 2023/07/16.
+//  Copyright © 2023 Lifepoo. All rights reserved.
+//
+
+import UIKit
+
+public extension String {
+    func nsAttributedString(fontSize: CGFloat, weight: UIFont.Weight, color: UIColor) -> NSAttributedString {
+        return NSAttributedString(string: self, attributes: [
+            .foregroundColor: color,
+            .font: UIFont.systemFont(ofSize: fontSize, weight: weight)
+        ])
+    }
+}

--- a/Projects/Features/FeatureHome/FeatureHomePresentation/Sources/FriendStoolStoryScene/FriendStoolStoryViewController.swift
+++ b/Projects/Features/FeatureHome/FeatureHomePresentation/Sources/FriendStoolStoryScene/FriendStoolStoryViewController.swift
@@ -61,7 +61,7 @@ public final class FriendStoolStoryViewController: LifePoopViewController, ViewT
     }()
     
     private let cheeringButton: LifePoopButton = {
-        let button = LifePoopButton(title: LocalizableString.boost)
+        let button = LifePoopButton()
         button.setTitle(LocalizableString.boost, for: .normal)
         button.setTitle(LocalizableString.doneBoost, for: .disabled)
         return button
@@ -120,11 +120,6 @@ public final class FriendStoolStoryViewController: LifePoopViewController, ViewT
         
         output.shouldEnableCheeringButton
             .bind(to: cheeringButton.rx.isEnabled)
-            .disposed(by: disposeBag)
-        
-        output.shouldUpdateCheeringButtonText
-            .debug()
-            .bind(to: cheeringButton.rx.title)
             .disposed(by: disposeBag)
         
         output.shouldUpdateCheeringLabelText

--- a/Projects/Features/FeatureHome/FeatureHomePresentation/Sources/HomeViewController.swift
+++ b/Projects/Features/FeatureHome/FeatureHomePresentation/Sources/HomeViewController.swift
@@ -53,7 +53,11 @@ public final class HomeViewController: LifePoopViewController, ViewType {
         return collectionView
     }()
     
-    private let stoolLogButton = LifePoopButton(title: LocalizableString.logStoolDiary)
+    private let stoolLogButton: LifePoopButton = {
+        let button = LifePoopButton()
+        button.setTitle(LocalizableString.logStoolDiary, for: .normal)
+        return button
+    }()
     
     public var viewModel: HomeViewModel?
     private let disposeBag = DisposeBag()

--- a/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/SignupScene/SignupViewController.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/SignupScene/SignupViewController.swift
@@ -99,7 +99,11 @@ public final class SignupViewController: LifePoopViewController, ViewType {
         return collectionView
     }()
     
-    private let nextButton = LifePoopButton(title: LocalizableString.next)
+    private let nextButton: LifePoopButton = {
+        let button = LifePoopButton()
+        button.setTitle(LocalizableString.next, for: .normal)
+        return button
+    }()
     
     private var sumOfVerticalMargins: CGFloat = .zero
     

--- a/Projects/Features/FeatureSetting/FeatureSettingPresentation/Sources/Feedback/FeedbackViewController.swift
+++ b/Projects/Features/FeatureSetting/FeatureSettingPresentation/Sources/Feedback/FeedbackViewController.swift
@@ -64,7 +64,8 @@ public final class FeedbackViewController: LifePoopViewController, ViewType {
     )
     
     private let sendButton: LifePoopButton = {
-        let button = LifePoopButton(title: "보내기")
+        let button = LifePoopButton()
+        button.setTitle("보내기", for: .normal)
         button.isEnabled = false
         return button
     }()

--- a/Projects/Features/FeatureSetting/FeatureSettingPresentation/Sources/ProfileEdit/ProfileEditViewController.swift
+++ b/Projects/Features/FeatureSetting/FeatureSettingPresentation/Sources/ProfileEdit/ProfileEditViewController.swift
@@ -44,7 +44,8 @@ public final class ProfileEditViewController: LifePoopViewController, ViewType {
     }()
     
     private let editConfirmButton: LifePoopButton = {
-        let button = LifePoopButton(title: LocalizableString.doneModification)
+        let button = LifePoopButton()
+        button.setTitle(LocalizableString.doneModification, for: .normal)
         button.isEnabled = false
         return button
     }()

--- a/Projects/Features/FeatureSetting/FeatureSettingPresentation/Sources/Withdrawal/WithdrawalViewController.swift
+++ b/Projects/Features/FeatureSetting/FeatureSettingPresentation/Sources/Withdrawal/WithdrawalViewController.swift
@@ -53,7 +53,8 @@ public final class WithdrawalViewController: LifePoopViewController, ViewType {
     private let withdrawAlertView = LifePoopAlertView(type: .withdraw)
     
     private lazy var withdrawButton: LifePoopButton = {
-        let button = LifePoopButton(title: "탈퇴하기")
+        let button = LifePoopButton()
+        button.setTitle("탈퇴하기", for: .normal)
         button.isEnabled = false
         return button
     }()

--- a/Projects/Features/FeatureStoolLog/FeatureStoolLogPresentation/Sources/Views/SatisfactionDetail/SatisfactionDetailViewController.swift
+++ b/Projects/Features/FeatureStoolLog/FeatureStoolLogPresentation/Sources/Views/SatisfactionDetail/SatisfactionDetailViewController.swift
@@ -81,7 +81,11 @@ public final class SatisfactionDetailViewController: LifePoopViewController, Vie
     
     private let sizeSelectionSegmentControl = LifePoopSegmentControl()
     
-    private let completeButton = LifePoopButton(title: LocalizableString.done)
+    private let completeButton: LifePoopButton = {
+        let button = LifePoopButton()
+        button.setTitle(LocalizableString.done, for: .normal)
+        return button
+    }()
     
     private let toastMessageLabel = ToastLabel()
     


### PR DESCRIPTION
### 🔖 관련 이슈
- #100 

<br> 

### ⚒️ 작업 내역

- [x] LifePoopButton에 대해 loading indicator와 함께 setTitle(for:) 메소드로 지정한 타이틀이 적절히 나타나도록 수정

<br>

### 📑 첨부 자료

#### 작업 이전

https://github.com/LifePoop/LifePoop_iOS/assets/57667738/ab91b9c7-796e-4877-af2d-a610d4792a32

#### 작업 이후

https://github.com/LifePoop/LifePoop_iOS/assets/57667738/eb12429e-fb25-4721-b34e-c6074f73012d
