### PR TITLE
LifePoopAlertView의 show(in:) 메소드 수정

### DIFF
--- a/Projects/DesignSystem/Sources/Component/UIView/LifePoopAlertView.swift
+++ b/Projects/DesignSystem/Sources/Component/UIView/LifePoopAlertView.swift
@@ -84,8 +84,8 @@ public class LifePoopAlertView: UIControl {
         fatalError("init(coder:) has not been implemented")
     }
     
-    public func show(in parentView: UIView) {
-        addViews(in: parentView)
+    public func show(in parentView: UIView, completion: (() -> Void)? = nil) {
+        addViews(in: parentView, completion: completion)
         fadeIn()
     }
     
@@ -112,7 +112,7 @@ public class LifePoopAlertView: UIControl {
 // MARK: - Supporting Methods
 
 private extension LifePoopAlertView {
-    func addViews(in parentView: UIView) {
+    func addViews(in parentView: UIView, completion: (() -> Void)? = nil) {
         parentView.addSubview(backgroundView)
         backgroundView.addSubview(self)
         backgroundView.frame = parentView.bounds
@@ -124,7 +124,8 @@ private extension LifePoopAlertView {
             make.bottom.equalTo(buttonStackView).offset(16)
             make.leading.trailing.equalToSuperview().inset(30)
         }
-        parentView.layoutIfNeeded()
+        
+        completion?()
     }
     
     func fadeIn() {

--- a/Projects/Features/FeatureFriendList/FeatureFriendListPresentation/Sources/InvitationCodeViewController/InvitationCodeViewController.swift
+++ b/Projects/Features/FeatureFriendList/FeatureFriendListPresentation/Sources/InvitationCodeViewController/InvitationCodeViewController.swift
@@ -96,7 +96,9 @@ public final class InvitationCodeViewController: LifePoopViewController, ViewTyp
 private extension InvitationCodeViewController {
     
     func showEnteringCodePopup() {
-        alertView.show(in: view)
+        alertView.show(in: view) { [weak self] in
+            self?.view.layoutIfNeeded()
+        }
         alertView.becomeFirstResponder()
     }
     


### PR DESCRIPTION

### 🔖 관련 이슈
- #110 

<br> 

### ⚒️ 작업 내역

- [x] parent view의 layoutIfNeeded를 직접 호출하는 대신, completion 블록을 매개변수로 받아 실행하도록 변경
