### PR TITLE
회원가입, 로그인 로직 수정 및 API 요청 적용

### DIFF
--- a/Projects/App/Attributes/Info.plist
+++ b/Projects/App/Attributes/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>CFBundleDevelopmentRegion</key>
@@ -75,9 +80,7 @@
 	<string>Light</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
-		<!-- 카카오톡으로 로그인 -->
 		<string>kakaokompassauth</string>
-		<!-- 카카오링크 -->
 		<string>kakaolink</string>
 	</array>
 </dict>

--- a/Projects/App/Sources/SceneDelegate.swift
+++ b/Projects/App/Sources/SceneDelegate.swift
@@ -124,6 +124,7 @@ private extension SceneDelegate {
         LoginDIContainer.shared.register(service: LoginUseCase.self) { DefaultLoginUseCase() }
         LoginDIContainer.shared.register(service: SignupUseCase.self) { DefaultSignupUseCase() }
         LoginDIContainer.shared.register(service: LoginRepository.self) { DefaultLoginRepository() }
+        LoginDIContainer.shared.register(service: SignupRepository.self) { DefaultSignupRepository() }
     }
     
     func registerHomeDependencies() {

--- a/Projects/App/Sources/SceneDelegate.swift
+++ b/Projects/App/Sources/SceneDelegate.swift
@@ -118,6 +118,8 @@ private extension SceneDelegate {
         SharedDIContainer.shared.register(service: BundleResourceRepository.self) { DefaultBundleResourceRepository() }
         SharedDIContainer.shared.register(service: UserDefaultsRepository.self) { DefaultUserDefaultsRepository() }
         SharedDIContainer.shared.register(service: KeyChainRepository.self) { DefaultKeyChainRepository() }
+        SharedDIContainer.shared.register(service: UserInfoUseCase.self) { DefaultUserInfoUseCase() }
+        SharedDIContainer.shared.register(service: UserInfoRepository.self) { DefaultUserInfoRepository() }
     }
     
     func registerLoginDependencies() {

--- a/Projects/Core/CoreAuthentication/Sources/Managers/AppleAuthManager.swift
+++ b/Projects/Core/CoreAuthentication/Sources/Managers/AppleAuthManager.swift
@@ -37,7 +37,6 @@ public final class AppleAuthManager: AuthManagable {
             .compactMap { $0.credential as? ASAuthorizationAppleIDCredential }
             .compactMap { $0.identityToken }
             .compactMap { String(data: $0, encoding: .utf8) }
-//            .map { AppleAuthResultEntity(accessToken: $0) }
             .asSingle()
     }
 }

--- a/Projects/Core/CoreAuthentication/Sources/Managers/AppleAuthManager.swift
+++ b/Projects/Core/CoreAuthentication/Sources/Managers/AppleAuthManager.swift
@@ -24,10 +24,7 @@ public final class AppleAuthManager: AuthManagable {
         guard !isAlreadyInitialized else { return }
         preparation?()
         
-        let serialQueue = DispatchQueue(label: "serial-queue-auth-auth")
-        serialQueue.sync {
-            _isAlreadyInitialized = true
-        }
+        _isAlreadyInitialized = true
     }
     
     public func fetchAccessToken() -> Single<String> {

--- a/Projects/Core/CoreAuthentication/Sources/Managers/KakaoAuthManager.swift
+++ b/Projects/Core/CoreAuthentication/Sources/Managers/KakaoAuthManager.swift
@@ -27,14 +27,10 @@ public final class KakaoAuthManager: AuthManagable {
         guard !isAlreadyInitialized else { return }
         
         preparation?()
-
-        let serialQueue = DispatchQueue(label: "serial-queue-kakao-auth")
-        serialQueue.sync {
-            // FIXME: 추후 키값 코드에서 감춰놔야 함
-            KakaoSDK.initSDK(appKey: "f7f327d46b7184823676acc9d0a2035c")
-            
-            _isAlreadyInitialized = true
-        }
+        // FIXME: 추후 키값 코드에서 감춰놔야 함
+        KakaoSDK.initSDK(appKey: "f7f327d46b7184823676acc9d0a2035c")
+        
+        _isAlreadyInitialized = true
     }
     
     public static func handleLoginUrl(_ url: URL) {

--- a/Projects/Core/CoreEntity/Sources/GenderType.swift
+++ b/Projects/Core/CoreEntity/Sources/GenderType.swift
@@ -10,7 +10,7 @@ import Foundation
 
 import Utils
 
-public enum GenderType: Int, CaseIterable, CustomStringConvertible {
+public enum GenderType: Int, CaseIterable, CustomStringConvertible, Codable {
     
     case female
     case male
@@ -34,4 +34,17 @@ public enum GenderType: Int, CaseIterable, CustomStringConvertible {
         case .other: return LocalizableString.other
         }
     }    
+    
+    public init?(stringValue: String) {
+        switch stringValue.uppercased() {
+        case "MALE":
+            self = .male
+        case "FEMALE":
+            self = .female
+        case "OTHER":
+            self = .other
+        default:
+            return nil
+        }
+    }
 }

--- a/Projects/Core/CoreEntity/Sources/GenderType.swift
+++ b/Projects/Core/CoreEntity/Sources/GenderType.swift
@@ -31,7 +31,7 @@ public enum GenderType: Int, CaseIterable, CustomStringConvertible, Codable {
         switch self {
         case .female: return LocalizableString.female
         case .male: return LocalizableString.male
-        case .other: return LocalizableString.other
+        case .other: return LocalizableString.etc
         }
     }    
     

--- a/Projects/Core/CoreEntity/Sources/GenderType.swift
+++ b/Projects/Core/CoreEntity/Sources/GenderType.swift
@@ -14,13 +14,24 @@ public enum GenderType: Int, CaseIterable, CustomStringConvertible {
     
     case female
     case male
-    case etc
+    case other
     
     public var description: String {
         switch self {
+        case .female:
+            "FEMALE"
+        case .male:
+            "MALE"
+        case .other:
+            "OTHER"
+        }
+    }
+    
+    public var localizedDescription: String {
+        switch self {
         case .female: return LocalizableString.female
         case .male: return LocalizableString.male
-        case .etc: return LocalizableString.etc
+        case .other: return LocalizableString.other
         }
     }    
 }

--- a/Projects/Core/CoreEntity/Sources/OAuthTokenInfo.swift
+++ b/Projects/Core/CoreEntity/Sources/OAuthTokenInfo.swift
@@ -1,0 +1,41 @@
+//
+//  UserAuthInfoEntity.swift
+//  CoreEntity
+//
+//  Created by 이준우 on 2023/05/30.
+//  Copyright © 2023 Lifepoo. All rights reserved.
+//
+
+import Foundation
+
+public struct OAuthTokenInfo: Codable {
+
+    public let loginType: LoginType?
+    public let accessToken: String
+
+    enum CodingKeys: String, CodingKey {
+        case accessToken
+        case loginType
+    }
+
+    public init(loginType: LoginType, accessToken: String) {
+        self.loginType = loginType
+        self.accessToken = accessToken
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        
+        let rawLoginType = try container.decode(String.self, forKey: .loginType)
+        self.loginType = LoginType(rawValue: rawLoginType) ?? .none
+        self.accessToken = try container.decode(String.self, forKey: .accessToken)
+        
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encode(loginType?.rawValue ?? "", forKey: .loginType)
+        try container.encode(accessToken, forKey: .accessToken)
+    }
+}

--- a/Projects/Core/CoreEntity/Sources/SignupInput.swift
+++ b/Projects/Core/CoreEntity/Sources/SignupInput.swift
@@ -1,0 +1,35 @@
+//
+//  SignupInfo.swift
+//  CoreEntity
+//
+//  Created by Lee, Joon Woo on 2023/09/26.
+//  Copyright © 2023 Lifepoo. All rights reserved.
+//
+
+import Foundation
+
+public struct SignupInput {
+    
+    public let nickname: String
+    public let birthDate: String
+    public let gender: GenderType
+    public let conditions: Set<AgreementCondition>
+    public let oAuthAccessToken: String
+    public let provider: LoginType
+    
+    public init(
+        nickname: String,
+        birthDate: String,
+        gender: GenderType,
+        conditions: Set<AgreementCondition>,
+        oAuthAccessToken: String,
+        provider: LoginType
+    ) {
+        self.nickname = nickname
+        self.birthDate = birthDate
+        self.gender = gender
+        self.conditions = conditions
+        self.oAuthAccessToken = oAuthAccessToken
+        self.provider = provider
+    }
+}

--- a/Projects/Core/CoreEntity/Sources/UserAuthInfoEntity.swift
+++ b/Projects/Core/CoreEntity/Sources/UserAuthInfoEntity.swift
@@ -2,25 +2,28 @@
 //  UserAuthInfoEntity.swift
 //  CoreEntity
 //
-//  Created by 이준우 on 2023/05/30.
+//  Created by Lee, Joon Woo on 2023/09/29.
 //  Copyright © 2023 Lifepoo. All rights reserved.
 //
 
 import Foundation
 
 public struct UserAuthInfoEntity: Codable {
-
+    
     public let loginType: LoginType?
     public let accessToken: String
+    public let refreshToken: String
 
     enum CodingKeys: String, CodingKey {
-        case accessToken
         case loginType
+        case accessToken
+        case refreshToken
     }
 
-    public init(loginType: LoginType, accessToken: String) {
+    public init(loginType: LoginType, accessToken: String, refreshToken: String) {
         self.loginType = loginType
         self.accessToken = accessToken
+        self.refreshToken = refreshToken
     }
     
     public init(from decoder: Decoder) throws {
@@ -29,7 +32,7 @@ public struct UserAuthInfoEntity: Codable {
         let rawLoginType = try container.decode(String.self, forKey: .loginType)
         self.loginType = LoginType(rawValue: rawLoginType) ?? .none
         self.accessToken = try container.decode(String.self, forKey: .accessToken)
-        
+        self.refreshToken = try container.decode(String.self, forKey: .refreshToken)
     }
     
     public func encode(to encoder: Encoder) throws {
@@ -37,5 +40,7 @@ public struct UserAuthInfoEntity: Codable {
 
         try container.encode(loginType?.rawValue ?? "", forKey: .loginType)
         try container.encode(accessToken, forKey: .accessToken)
+        try container.encode(refreshToken, forKey: .refreshToken)
     }
+
 }

--- a/Projects/Core/CoreEntity/Sources/UserInfoEntity.swift
+++ b/Projects/Core/CoreEntity/Sources/UserInfoEntity.swift
@@ -12,11 +12,27 @@ public struct UserInfoEntity: Codable {
     
     public let userId: Int
     public let nickname: String
+    public let birthDate: String
+    public let genderType: GenderType
+    public let profileCharacter: ProfileCharacter
+    public let invitationCode: String
     public let authInfo: UserAuthInfoEntity
     
-    public init(userId: Int, nickname: String, authInfo: UserAuthInfoEntity) {
+    public init(
+        userId: Int,
+        nickname: String,
+        birthDate: String,
+        genderType: GenderType,
+        profileCharacter: ProfileCharacter,
+        invitationCode: String,
+        authInfo: UserAuthInfoEntity) {
+            
         self.userId = userId
         self.nickname = nickname
+        self.birthDate = birthDate
+        self.genderType = genderType
+        self.profileCharacter = profileCharacter
+        self.invitationCode = invitationCode
         self.authInfo = authInfo
     }
 }

--- a/Projects/Core/CoreNetworkService/Sources/DTO/UserInfoDTO.swift
+++ b/Projects/Core/CoreNetworkService/Sources/DTO/UserInfoDTO.swift
@@ -1,0 +1,20 @@
+//
+//  UserInfoDTO.swift
+//  CoreNetworkService
+//
+//  Created by Lee, Joon Woo on 2023/09/30.
+//  Copyright © 2023 Lifepoo. All rights reserved.
+//
+
+import Foundation
+
+public struct UserInfoDTO: Codable {
+    
+    public let id: Int
+    public let nickname: String
+    public let birth: String
+    public let sex: String
+    public let characterColor: Int
+    public let characterShape: Int
+    public let inviteCode: String
+}

--- a/Projects/Core/CoreNetworkService/Sources/HTTPComponent/NetworkResult.swift
+++ b/Projects/Core/CoreNetworkService/Sources/HTTPComponent/NetworkResult.swift
@@ -16,6 +16,18 @@ public struct NetworkResult {
         return response.statusCode
     }
     
+    public var cookies: [String: String]? {
+        guard let allHeaderFields = response.allHeaderFields as? [String: String],
+              let url = response.url else { return nil }
+
+        var cookies: [String: String] = [:]
+        HTTPCookie.cookies(withResponseHeaderFields: allHeaderFields, for: url).forEach {
+            cookies[$0.name] = $0.value
+        }
+        
+        return cookies
+    }
+    
     public init(data: Data?, response: HTTPURLResponse) {
         self.data = data
         self.response = response

--- a/Projects/Core/CoreNetworkService/Sources/Service/Interface/EndpointService.swift
+++ b/Projects/Core/CoreNetworkService/Sources/Service/Interface/EndpointService.swift
@@ -13,6 +13,7 @@ import RxSwift
 public protocol EndpointService {
     func fetchData<E: Encodable>(endpoint: TargetType, with bodyObject: E) -> Single<Data>
     func fetchStatusCode<E: Encodable>(endpoint: TargetType, with bodyObject: E) -> Single<Int>
+    func fetchNetworkResult<E: Encodable>(endpoint: TargetType, with bodyObject: E) -> Single<NetworkResult>
 }
 
 public extension EndpointService {
@@ -23,4 +24,9 @@ public extension EndpointService {
     func fetchStatusCode(endpoint: TargetType) -> Single<Int> {
         fetchStatusCode(endpoint: endpoint, with: EmptyBody())
     }
+    
+    func fetchNetworkResult(endpoint: TargetType) -> Single<NetworkResult> {
+        fetchNetworkResult(endpoint: endpoint, with: EmptyBody())
+    }
+
 }

--- a/Projects/Core/CoreNetworkService/Sources/Service/URLSessionEndpointService.swift
+++ b/Projects/Core/CoreNetworkService/Sources/Service/URLSessionEndpointService.swift
@@ -24,10 +24,11 @@ public final class URLSessionEndpointService: EndpointService {
     
     public func fetchStatusCode<E: Encodable>(endpoint: TargetType, with bodyObject: E) -> Single<Int> {
         return performRequest(endpoint: endpoint, bodyObject: bodyObject)
-//            .do(onSuccess: {
-//                print($0)
-//            })
             .map { $0.statusCode }
+    }
+    
+    public func fetchNetworkResult<E>(endpoint: TargetType, with bodyObject: E) -> Single<NetworkResult> where E : Encodable {
+        return performRequest(endpoint: endpoint, bodyObject: bodyObject)
     }
 }
 
@@ -61,6 +62,18 @@ private extension URLSessionEndpointService {
                 request.addValue(value, forHTTPHeaderField: key)
             }
         }
+        
+        // MARK: 필요 시 요청 헤더에 쿠키 추가
+        let cookies: [HTTPCookie] = endpoint.cookies.compactMap { key, value in
+            HTTPCookie(properties: [
+                .name: key,
+                .value: value,
+                .domain: finalUrl.host ?? "api.lifepoo.link",
+                .path: "/",
+            ])
+        }
+        let cookieHeaderValue = HTTPCookie.requestHeaderFields(with: cookies)["Cookie"]
+        request.setValue(cookieHeaderValue, forHTTPHeaderField: "Cookie")
         
         if bodyObject is EmptyBody {
             return request

--- a/Projects/Core/CoreNetworkService/Sources/Service/URLSessionEndpointService.swift
+++ b/Projects/Core/CoreNetworkService/Sources/Service/URLSessionEndpointService.swift
@@ -24,6 +24,9 @@ public final class URLSessionEndpointService: EndpointService {
     
     public func fetchStatusCode<E: Encodable>(endpoint: TargetType, with bodyObject: E) -> Single<Int> {
         return performRequest(endpoint: endpoint, bodyObject: bodyObject)
+//            .do(onSuccess: {
+//                print($0)
+//            })
             .map { $0.statusCode }
     }
 }

--- a/Projects/Core/CoreNetworkService/Sources/Target/Interface/TargetType.swift
+++ b/Projects/Core/CoreNetworkService/Sources/Target/Interface/TargetType.swift
@@ -13,5 +13,6 @@ public protocol TargetType {
     var path: String { get }
     var method: HTTPMethod { get }
     var headers: [String: String]? { get }
+    var cookies: [String: String] { get }
     var parameters: [String: Any]? { get }
 }

--- a/Projects/Core/CoreNetworkService/Sources/Target/LifePoopLocalTarget.swift
+++ b/Projects/Core/CoreNetworkService/Sources/Target/LifePoopLocalTarget.swift
@@ -10,23 +10,22 @@ import Foundation
 
 public enum LifePoopLocalTarget {
     case login(provider: String)
+    case updateAccessToken(refreshToken: String)
     case signup(provider: String)
+    case fetchUserInfo(accessToken: String)
     case fetchStoolLog(userID: Int)
     case postStoolLog(accessToken: String)
 }
 
 extension LifePoopLocalTarget: TargetType {
     public var baseURL: URL? {
-        switch self {
-        case .login, .signup:
-            return URL(string: "https://api.lifepoo.link")
-        case .fetchStoolLog, .postStoolLog:
-            return URL(string: "http://localhost:3000")
-        }
+        URL(string: "http://localhost:3000")
     }
     
     public var path: String {
         switch self {
+        case .updateAccessToken:
+            return "/auth/refresh"
         case .signup(let provider):
             return "/auth/\(provider)/register"
         case .login(let provider):
@@ -35,39 +34,48 @@ extension LifePoopLocalTarget: TargetType {
             return "/post/\(userID)"
         case .postStoolLog:
             return "/post"
+        case .fetchUserInfo:
+            return "/user"
         }
     }
     
     public var method: HTTPMethod {
         switch self {
-        case .login, .signup:
-            return .post
-        case .fetchStoolLog:
+        case .fetchStoolLog, .fetchUserInfo:
             return .get
-        case .postStoolLog:
+        case .postStoolLog, .login, .signup, .updateAccessToken:
             return .post
         }
     }
     
     public var headers: [String: String]? {
         switch self {
-        case .signup, .login, .fetchStoolLog:
-            return [
-                "Content-Type": "application/json",
-                "Accept": "application/json",
-            ]
-        case .postStoolLog(let accessToken):
+        case .postStoolLog(let accessToken), .fetchUserInfo(let accessToken):
             return [
                 "Content-Type": "application/json",
                 "Accept": "application/json",
                 "Authorization": "Bearer \(accessToken)"
             ]
+        default:
+            return [
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            ]
         }
     }
-    
+
+    public var cookies: [String: String] {
+        switch self {
+        case .updateAccessToken(let refreshToken):
+            return ["refresh_token": refreshToken]
+        default:
+            return [:]
+        }
+    }
+
     public var parameters: [String: Any]? {
         switch self {
-        case .signup, .login, .fetchStoolLog, .postStoolLog:
+        case .signup, .login, .fetchStoolLog, .postStoolLog, .updateAccessToken, .fetchUserInfo:
             return nil
         }
     }

--- a/Projects/Core/CoreNetworkService/Sources/Target/LifePoopLocalTarget.swift
+++ b/Projects/Core/CoreNetworkService/Sources/Target/LifePoopLocalTarget.swift
@@ -19,7 +19,9 @@ public enum LifePoopLocalTarget {
 
 extension LifePoopLocalTarget: TargetType {
     public var baseURL: URL? {
-        URL(string: "http://localhost:3000")
+        // MARK: 실서버 요청 확인할 경우 아래 url로 사용
+//        URL(string: "https://api.lifepoo.link")
+        URL(string: "http:localhost:3000")
     }
     
     public var path: String {

--- a/Projects/Core/CoreNetworkService/Sources/Target/LifePoopLocalTarget.swift
+++ b/Projects/Core/CoreNetworkService/Sources/Target/LifePoopLocalTarget.swift
@@ -9,7 +9,8 @@
 import Foundation
 
 public enum LifePoopLocalTarget {
-    case login(accessToken: String, provider: String)
+    case login(provider: String)
+    case signup(provider: String)
     case fetchStoolLog(userID: Int)
     case postStoolLog(accessToken: String)
 }
@@ -17,15 +18,19 @@ public enum LifePoopLocalTarget {
 extension LifePoopLocalTarget: TargetType {
     public var baseURL: URL? {
         switch self {
-        case .login, .fetchStoolLog, .postStoolLog:
+        case .login, .signup:
+            return URL(string: "https://api.lifepoo.link")
+        case .fetchStoolLog, .postStoolLog:
             return URL(string: "http://localhost:3000")
         }
     }
     
     public var path: String {
         switch self {
-        case .login:
-            return "/auth/*/login"
+        case .signup(let provider):
+            return "/auth/\(provider)/register"
+        case .login(let provider):
+            return "/auth/\(provider)/login"
         case .fetchStoolLog(let userID):
             return "/post/\(userID)"
         case .postStoolLog:
@@ -35,7 +40,7 @@ extension LifePoopLocalTarget: TargetType {
     
     public var method: HTTPMethod {
         switch self {
-        case .login:
+        case .login, .signup:
             return .post
         case .fetchStoolLog:
             return .get
@@ -46,10 +51,11 @@ extension LifePoopLocalTarget: TargetType {
     
     public var headers: [String: String]? {
         switch self {
-        case .login:
-            return nil
-        case .fetchStoolLog:
-            return nil
+        case .signup, .login, .fetchStoolLog:
+            return [
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            ]
         case .postStoolLog(let accessToken):
             return [
                 "Content-Type": "application/json",
@@ -61,12 +67,7 @@ extension LifePoopLocalTarget: TargetType {
     
     public var parameters: [String: Any]? {
         switch self {
-        case .login(let accessToken, let provider):
-            return [
-                "accessToken": accessToken,
-                "provider": provider
-            ]
-        case .fetchStoolLog, .postStoolLog:
+        case .signup, .login, .fetchStoolLog, .postStoolLog:
             return nil
         }
     }

--- a/Projects/Core/CoreNetworkService/Sources/Target/LifePoopLocalTarget.swift
+++ b/Projects/Core/CoreNetworkService/Sources/Target/LifePoopLocalTarget.swift
@@ -21,7 +21,7 @@ extension LifePoopLocalTarget: TargetType {
     public var baseURL: URL? {
         // MARK: 실서버 요청 확인할 경우 아래 url로 사용
 //        URL(string: "https://api.lifepoo.link")
-        URL(string: "http:localhost:3000")
+        URL(string: "http://localhost:3000")
     }
     
     public var path: String {

--- a/Projects/Core/CoreNetworkService/Sources/Target/LifePoopTarget.swift
+++ b/Projects/Core/CoreNetworkService/Sources/Target/LifePoopTarget.swift
@@ -15,6 +15,7 @@ public enum LifePoopTarget {
 }
 
 extension LifePoopTarget: TargetType {
+    
     public var baseURL: URL? {
         switch self {
         case .fetchTempCode, .fetchAccessToken:
@@ -37,6 +38,13 @@ extension LifePoopTarget: TargetType {
             return .get
         case .fetchAccessToken:
             return .post
+        }
+    }
+    
+    public var cookies: [String: String] {
+        switch self {
+        default:
+            return [:]
         }
     }
     

--- a/Projects/Features/FeatureLogin/FeatureLoginCoordinator/Sources/DefaultLoginCoordinator.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginCoordinator/Sources/DefaultLoginCoordinator.swift
@@ -39,9 +39,9 @@ public final class DefaultLoginCoordinator: LoginCoordinator {
         switch coordinateAction {
         case .shouldShowLaunchScreen:
             showLaunchScreenViewController()
-        case .shouldSkipLoginFlow:
+        case .skipLoginFlow:
             skipFlow()
-        case .shouldShowLoginScene:
+        case .showLoginScene:
             showLoginViewController()
         case .shouldShowDetailForm(let title, let detailText):
             showDocumentViewController(title: title, detailText: detailText)
@@ -79,7 +79,7 @@ private extension DefaultLoginCoordinator {
         navigationController.pushViewController(viewController, animated: false)
     }
     
-    func showNicknameViewController(with authInfo: UserAuthInfoEntity) {
+    func showNicknameViewController(with authInfo: OAuthTokenInfo) {
         let viewController = SignupViewController()
         let viewModel = SignupViewModel(coordinator: self, authInfo: authInfo)
         viewController.bind(viewModel: viewModel)

--- a/Projects/Features/FeatureLogin/FeatureLoginCoordinator/Sources/DefaultLoginCoordinator.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginCoordinator/Sources/DefaultLoginCoordinator.swift
@@ -36,23 +36,25 @@ public final class DefaultLoginCoordinator: LoginCoordinator {
     }
     
     public func coordinate(by coordinateAction: LoginCoordinateAction) {
-        switch coordinateAction {
-        case .shouldShowLaunchScreen:
-            showLaunchScreenViewController()
-        case .skipLoginFlow:
-            skipFlow()
-        case .showLoginScene:
-            showLoginViewController()
-        case .shouldShowDetailForm(let title, let detailText):
-            showDocumentViewController(title: title, detailText: detailText)
-        case .didTapKakaoLoginButton(let authInfo):
-            showNicknameViewController(with: authInfo)
-        case .didTapAppleLoginButton(let authInfo):
-            showNicknameViewController(with: authInfo)
-        case .shouldFinishLoginFlow:
-            finishFlow()
-        case .shouldPopCurrentScene:
-            popCurrentViewController()
+        DispatchQueue.main.async { [weak self] in
+            switch coordinateAction {
+            case .shouldShowLaunchScreen:
+                self?.showLaunchScreenViewController()
+            case .skipLoginFlow:
+                self?.skipFlow()
+            case .showLoginScene:
+                self?.showLoginViewController()
+            case .shouldShowDetailForm(let title, let detailText):
+                self?.showDocumentViewController(title: title, detailText: detailText)
+            case .didTapKakaoLoginButton(let authInfo):
+                self?.showNicknameViewController(with: authInfo)
+            case .didTapAppleLoginButton(let authInfo):
+                self?.showNicknameViewController(with: authInfo)
+            case .shouldFinishLoginFlow:
+                self?.finishFlow()
+            case .shouldPopCurrentScene:
+                self?.popCurrentViewController()
+            }
         }
     }
     

--- a/Projects/Features/FeatureLogin/FeatureLoginCoordinatorInterface/Sources/LoginCoordinateAction.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginCoordinatorInterface/Sources/LoginCoordinateAction.swift
@@ -12,11 +12,11 @@ import CoreEntity
 
 public enum LoginCoordinateAction {
     case shouldShowLaunchScreen
-    case shouldSkipLoginFlow
-    case shouldShowLoginScene
+    case skipLoginFlow
+    case showLoginScene
     case shouldShowDetailForm(title: String, detailText: String)
     case shouldPopCurrentScene
-    case didTapAppleLoginButton(userAuthInfo: UserAuthInfoEntity)
-    case didTapKakaoLoginButton(userAuthInfo: UserAuthInfoEntity)
+    case didTapAppleLoginButton(userAuthInfo: OAuthTokenInfo)
+    case didTapKakaoLoginButton(userAuthInfo: OAuthTokenInfo)
     case shouldFinishLoginFlow
 }

--- a/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/LaunchScreen/LaunchScreenViewModel.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/LaunchScreen/LaunchScreenViewModel.swift
@@ -39,10 +39,11 @@ public final class LaunchScreenViewModel: ViewModelType {
     public init(coordinator: LoginCoordinator?) {
         self.coordinator = coordinator
         
+        // MARK: 앱 설치 후 최초 기동 시에 기존 사용자 정보 삭제
         let preparationResult = input.viewWillAppear
             .withUnretained(self)
             .flatMapCompletableMaterialized { `self`, _ in
-                self.loginUseCase.clearUserAuthInfoIfNeeded()
+                self.loginUseCase.clearUserAuthInfoIfLaunchedFirstly()
             }
             .share()
         
@@ -58,28 +59,20 @@ public final class LaunchScreenViewModel: ViewModelType {
             })
             .disposed(by: disposeBag)
         
+        // MARK: LaunchScreen 애니메이션 처리 및 부가 작업 끝나면 자동 로그인 시도
         Observable.zip(
             input.didFinishAnimating,
             input.didFinishPreparation
         )
         .withUnretained(self)
-        .flatMapLatest { `self`, _ in
-            self.loginUseCase.userInfo
-        }
-        .withUnretained(self)
-        .flatMapLatest { `self`, userInfo in
-            // MARK: 기기에 인증 정보가 존재하면 유효성 검증 위해 자동으로 로그인 요청
-            if let userAuthInfo = userInfo?.authInfo {
-                return self.loginUseCase.requestSignin(with: userAuthInfo)
-            } else {
-                return Observable.just(false)
-            }
-        }
+        .flatMapLatest { $0.0.loginUseCase.requestAutoLoginWithExistingUserInfo() }
+        .asObservable()
+        .observe(on: MainScheduler.asyncInstance)
         .bind(onNext: { hasToken in
             if hasToken {
-                coordinator?.coordinate(by: .shouldSkipLoginFlow)
+                coordinator?.coordinate(by: .skipLoginFlow)
             } else {
-                coordinator?.coordinate(by: .shouldShowLoginScene)
+                coordinator?.coordinate(by: .showLoginScene)
             }
         })
         .disposed(by: disposeBag)

--- a/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/LaunchScreen/LaunchScreenViewModel.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/LaunchScreen/LaunchScreenViewModel.swift
@@ -67,7 +67,6 @@ public final class LaunchScreenViewModel: ViewModelType {
         .withUnretained(self)
         .flatMapLatest { $0.0.loginUseCase.requestAutoLoginWithExistingUserInfo() }
         .asObservable()
-        .observe(on: MainScheduler.asyncInstance)
         .bind(onNext: { hasToken in
             if hasToken {
                 coordinator?.coordinate(by: .skipLoginFlow)

--- a/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/LoginScene/LoginViewModel.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/LoginScene/LoginViewModel.swift
@@ -97,12 +97,14 @@ public final class LoginViewModel: ViewModelType {
                     .map { (userAuthInfo: userAuthInfo, isSuccess: $0 ) }
             }
             .bind(onNext: { userAuthInfo, isSuccess in
-                if isSuccess {
-                    coordinator?.coordinate(by: .shouldFinishLoginFlow)
-                } else {
-                    coordinator?.coordinate(
-                        by: .didTapAppleLoginButton(userAuthInfo: userAuthInfo)
-                    )
+                DispatchQueue.main.async {
+                    if isSuccess {
+                        coordinator?.coordinate(by: .shouldFinishLoginFlow)
+                    } else {
+                        coordinator?.coordinate(
+                            by: .didTapAppleLoginButton(userAuthInfo: userAuthInfo)
+                        )
+                    }
                 }
             })
             .disposed(by: disposeBag)

--- a/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/LoginScene/LoginViewModel.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/LoginScene/LoginViewModel.swift
@@ -62,15 +62,17 @@ public final class LoginViewModel: ViewModelType {
             .withUnretained(self)
             .flatMapLatest { `self`, oAuthTokenInfo in
                 self.loginUseCase.requestLogin(with: oAuthTokenInfo)
-                    .map { (oAuthTokenInfo: oAuthTokenInfo, isSuccess: $0 ) }
+                    .map { (oAuthTokenInfo: oAuthTokenInfo, loginResult: $0 ) }
             }
-            .bind(onNext: { oAuthTokenInfo, isSuccess in
-                if isSuccess {
-                    coordinator?.coordinate(by: .shouldFinishLoginFlow)
-                } else {
-                    coordinator?.coordinate(
-                        by: .didTapKakaoLoginButton(userAuthInfo: oAuthTokenInfo)
-                    )
+            .bind(onNext: { [weak self] oAuthTokenInfo, loginResult in
+                switch loginResult {
+                case .success(let isSuccess):
+                    isSuccess ? coordinator?.coordinate(by: .shouldFinishLoginFlow)
+                              : coordinator?.coordinate(
+                                    by: .didTapKakaoLoginButton(userAuthInfo: oAuthTokenInfo)
+                                )
+                case .failure(let error):
+                    self?.output.showErrorMessage.accept(error.localizedDescription)
                 }
             })
             .disposed(by: disposeBag)
@@ -94,15 +96,17 @@ public final class LoginViewModel: ViewModelType {
             .withUnretained(self)
             .flatMapLatest { `self`, oAuthTokenInfo in
                 self.loginUseCase.requestLogin(with: oAuthTokenInfo)
-                    .map { (oAuthTokenInfo: oAuthTokenInfo, isSuccess: $0 ) }
+                    .map { (oAuthTokenInfo: oAuthTokenInfo, loginResult: $0 ) }
             }
-            .bind(onNext: { oAuthTokenInfo, isSuccess in
-                if isSuccess {
-                    coordinator?.coordinate(by: .shouldFinishLoginFlow)
-                } else {
-                    coordinator?.coordinate(
-                        by: .didTapAppleLoginButton(userAuthInfo: oAuthTokenInfo)
-                    )
+            .bind(onNext: { [weak self] oAuthTokenInfo, loginResult in
+                switch loginResult {
+                case .success(let isSuccess):
+                    isSuccess ? coordinator?.coordinate(by: .shouldFinishLoginFlow)
+                              : coordinator?.coordinate(
+                                    by: .didTapAppleLoginButton(userAuthInfo: oAuthTokenInfo)
+                                )
+                case .failure(let error):
+                    self?.output.showErrorMessage.accept(error.description)
                 }
             })
             .disposed(by: disposeBag)

--- a/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/LoginScene/LoginViewModel.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/LoginScene/LoginViewModel.swift
@@ -96,7 +96,6 @@ public final class LoginViewModel: ViewModelType {
                 self.loginUseCase.requestLogin(with: oAuthTokenInfo)
                     .map { (oAuthTokenInfo: oAuthTokenInfo, isSuccess: $0 ) }
             }
-            .observe(on: MainScheduler.asyncInstance)
             .bind(onNext: { oAuthTokenInfo, isSuccess in
                 if isSuccess {
                     coordinator?.coordinate(by: .shouldFinishLoginFlow)

--- a/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/SignupScene/SignupViewController.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/SignupScene/SignupViewController.swift
@@ -158,7 +158,7 @@ public final class SignupViewController: LifePoopViewController, ViewType {
         
         birthdayTextField.rx.textChanged
             .skip(1)
-            .bind(to: input.didEnterBirthday)
+            .bind(to: input.didEnterBirthDate)
             .disposed(by: disposeBag)
         
         nicknameTextField.rx.controlEvent(.editingDidEndOnExit)

--- a/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/SignupScene/SignupViewController.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/SignupScene/SignupViewController.swift
@@ -54,7 +54,7 @@ public final class SignupViewController: LifePoopViewController, ViewType {
     private let genderSelectionButtons: [TextSelectionButton] = GenderType.allCases.map {
         TextSelectionButton(
             index: $0.index,
-            title: $0.description,
+            title: $0.localizedDescription,
             backgroundColor: .init(
                 selected: ColorAsset.primary.color,
                 deselected: ColorAsset.gray300.color

--- a/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/SignupScene/SignupViewModel.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/SignupScene/SignupViewModel.swift
@@ -199,7 +199,6 @@ public final class SignupViewModel: ViewModelType {
             .flatMapLatest { `self`, signupInfo in
                 self.signupUseCase.requestSignup(signupInfo)
             }
-            .observe(on: MainScheduler.asyncInstance)
             .bind(onNext: { isSuccess in
                 guard isSuccess else { return }
                 coordinator.coordinate(by: .shouldFinishLoginFlow)

--- a/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/SignupScene/SignupViewModel.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/SignupScene/SignupViewModel.swift
@@ -20,14 +20,6 @@ import SharedDIContainer
 import SharedUseCase
 import Utils
 
-public struct SignupInfo {
-    
-    let nickname: String
-    let birthDate: String
-    let gender: GenderType?
-    let conditions: Set<AgreementCondition>
-}
-
 public final class SignupViewModel: ViewModelType {
 
     enum DetailViewType {
@@ -44,7 +36,7 @@ public final class SignupViewModel: ViewModelType {
     public struct Input {
         let didTapNextButton = PublishRelay<Void>()
         let didEnterNickname = PublishRelay<String>()
-        let didEnterBirthday = PublishRelay<String>()
+        let didEnterBirthDate = PublishRelay<String>()
         let didTapSelectAllCondition = PublishRelay<Bool>()
         let didSelectConfirmCondition = PublishRelay<AgreementCondition>()
         let didDeselectConfirmCondition = PublishRelay<AgreementCondition>()
@@ -130,7 +122,7 @@ public final class SignupViewModel: ViewModelType {
             .bind(to: output.nicknameTextFieldStatus)
             .disposed(by: disposeBag)
         
-        let birthdayInputStatus = input.didEnterBirthday
+        let birthdayInputStatus = input.didEnterBirthDate
             .withUnretained(self)
             .flatMap { `self`, input in
                 self.signupUseCase.isBirthdayInputValid(input)
@@ -169,7 +161,7 @@ public final class SignupViewModel: ViewModelType {
         let signupInfo = Observable
             .combineLatest(
                 input.didEnterNickname,
-                input.didEnterBirthday,
+                input.didEnterBirthDate,
                 output.shouldSelectGender,
                 state.selectedConditions
             )

--- a/Projects/Features/FeatureLogin/FeatureLoginRepository/Sources/DefaultLoginRepository.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginRepository/Sources/DefaultLoginRepository.swift
@@ -38,7 +38,12 @@ public final class DefaultLoginRepository: NSObject, LoginRepository {
         guard let loginType = userAuthInfo.loginType else { return Single.just(false) }
         
         return urlSessionEndpointService
-            .fetchStatusCode(endpoint: LifePoopLocalTarget.login(accessToken: userAuthInfo.accessToken, provider: loginType.description))
+            .fetchStatusCode(
+                endpoint: LifePoopLocalTarget.login(
+                    provider: loginType.description
+                ),
+                with: ["oAuthAccessToken": userAuthInfo.accessToken]
+            )
             .asObservable()
             .map { $0 >= 200 && $0 < 300 }
             .catchAndReturn(false)

--- a/Projects/Features/FeatureLogin/FeatureLoginRepository/Sources/DefaultLoginRepository.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginRepository/Sources/DefaultLoginRepository.swift
@@ -76,7 +76,6 @@ public final class DefaultLoginRepository: NSObject, LoginRepository {
                 )
             }
             .asSingle()
-            .catchAndReturn(nil)
     }
 }
 

--- a/Projects/Features/FeatureLogin/FeatureLoginRepository/Sources/DefaultSignupRepository.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginRepository/Sources/DefaultSignupRepository.swift
@@ -7,3 +7,34 @@
 //
 
 import Foundation
+import RxSwift
+
+import CoreDIContainer
+import CoreEntity
+import CoreNetworkService
+import FeatureLoginUseCase
+import Utils
+
+public final class DefaultSignupRepository: NSObject, SignupRepository {
+    
+    @Inject(CoreDIContainer.shared) private var urlSessionEndpointService: EndpointService
+    
+    public override init() { }
+    
+    public func requestSignup(with signupInfo: SignupInput) -> Single<Bool> {
+        return urlSessionEndpointService
+            .fetchStatusCode(
+                endpoint: LifePoopLocalTarget.signup(provider: signupInfo.provider.description),
+                with: [
+                    "nickname": signupInfo.nickname,
+                    "birth": signupInfo.birthDate,
+                    "sex": signupInfo.gender.description,
+                    "oAuthAccessToken": signupInfo.oAuthAccessToken
+                ]
+            )
+            .asObservable()
+            .map { $0 >= 200 && $0 < 300 }
+            .catchAndReturn(false)
+            .asSingle()
+    }
+}

--- a/Projects/Features/FeatureLogin/FeatureLoginRepository/Sources/DefaultSignupRepository.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginRepository/Sources/DefaultSignupRepository.swift
@@ -1,0 +1,9 @@
+//
+//  DefaultSignupRepository.swift
+//  FeatureLoginRepository
+//
+//  Created by Lee, Joon Woo on 2023/09/26.
+//  Copyright © 2023 Lifepoo. All rights reserved.
+//
+
+import Foundation

--- a/Projects/Features/FeatureLogin/FeatureLoginRepository/Sources/DefaultSignupRepository.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginRepository/Sources/DefaultSignupRepository.swift
@@ -21,20 +21,57 @@ public final class DefaultSignupRepository: NSObject, SignupRepository {
     
     public override init() { }
     
-    public func requestSignup(with signupInfo: SignupInput) -> Single<Bool> {
-        return urlSessionEndpointService
-            .fetchStatusCode(
-                endpoint: LifePoopLocalTarget.signup(provider: signupInfo.provider.description),
+    public func requestSignup(with signupInput: SignupInput) -> Single<UserAuthInfoEntity> {
+        urlSessionEndpointService
+            .fetchNetworkResult(
+                endpoint: LifePoopLocalTarget.signup(provider: signupInput.provider.description),
                 with: [
-                    "nickname": signupInfo.nickname,
-                    "birth": signupInfo.birthDate,
-                    "sex": signupInfo.gender.description,
-                    "oAuthAccessToken": signupInfo.oAuthAccessToken
+                    "nickname": signupInput.nickname,
+                    "birth": signupInput.birthDate,
+                    "sex": signupInput.gender.description,
+                    "oAuthAccessToken": signupInput.oAuthAccessToken
                 ]
             )
-            .asObservable()
-            .map { $0 >= 200 && $0 < 300 }
-            .catchAndReturn(false)
-            .asSingle()
+            .map { networkResult -> UserAuthInfoEntity in
+                let statusCode = networkResult.statusCode
+                guard statusCode >= 200 && statusCode < 300 else {
+                    throw NetworkError.invalidStatusCode(code: statusCode)
+                }
+
+                var accessToken: String?
+                var refreshToken: String?
+                
+                // MARK: AccessToken 추출
+                if let bodyData = networkResult.data {
+                    let body = try JSONDecoder().decode([String: String].self, from: bodyData)
+                    accessToken = body["accessToken"]
+                }
+                
+                // MARK: RefreshToken 추출
+                if let cookies = networkResult.cookies {
+                    refreshToken = cookies["refresh_token"]
+                }
+
+                return try self.createUserAuthInfo(
+                    accessToken: accessToken,
+                    refreshToken: refreshToken,
+                    loginType: signupInput.provider
+                )
+            }
+            .logErrorIfDetected(category: .network, type: .error)
+    }
+
+    private func createUserAuthInfo(accessToken: String?, refreshToken: String?, loginType: LoginType?) throws -> UserAuthInfoEntity {
+        guard let accessToken = accessToken,
+              let refreshToken = refreshToken,
+              let loginType = loginType else {
+            throw NetworkError.invalidResponse
+        }
+        
+        return UserAuthInfoEntity(
+            loginType: loginType,
+            accessToken: accessToken,
+            refreshToken: refreshToken
+        )
     }
 }

--- a/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/DefaultLoginUseCase.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/DefaultLoginUseCase.swift
@@ -16,6 +16,12 @@ import SharedUseCase
 import Utils
 
 public final class DefaultLoginUseCase: LoginUseCase {
+    
+    enum LoginError: Error {
+        case refreshingTokenFailed
+    }
+
+    @Inject(SharedDIContainer.shared) private var userInfoUseCase: UserInfoUseCase
 
     @Inject(LoginDIContainer.shared) private var loginRepository: LoginRepository
     @Inject(SharedDIContainer.shared) private var keyChainRepository: KeyChainRepository
@@ -23,43 +29,73 @@ public final class DefaultLoginUseCase: LoginUseCase {
 
     public init() { }
     
-    public var userInfo: Observable<UserInfoEntity?> {
-        keyChainRepository
-            .getObjectFromKeyChain(asTypeOf: UserInfoEntity.self, forKey: .userAuthInfo)
-            .logErrorIfDetected(category: .authentication)
-            .catchAndReturn(nil)
-            .asObservable()
-            .do(onNext: { userInfo in
-                let nickname = userInfo?.nickname ?? "nil"
-                let loginType = userInfo?.authInfo.loginType?.rawValue ?? "nil"
+    /** 로컬 기기에 저장된 사용자 정보로 자동 로그인 처리 요청 */
+    public func requestAutoLoginWithExistingUserInfo() -> Observable<Bool> {
+        userInfoUseCase.userInfo
+            .withUnretained(self)
+            .flatMapLatest { `self`, userInfo in
+                
                 Logger.log(
-                    message: "사용자 정보 확인: \(nickname), 로그인 유형: \(loginType)",
+                    message: "기기에 기존 인증정보 존재 확인 : \(userInfo != nil)",
+                    category: .authentication,
+                    type: .debug
+                )
+                
+                if let authInfo = userInfo?.authInfo {
+                    return self.userInfoUseCase.refreshAuthInfo(with: authInfo)
+                } else {
+                    return Observable.just(false)
+                }
+            }
+    }
+    
+    /** OAuth 토큰 정보로 Lifepoo Access Token, Refresh Token 획득 및 로그인 처리 요청 */
+    public func requestLogin(with oAuthTokenInfo: OAuthTokenInfo) -> Observable<Bool> {
+        loginRepository
+            .requestAuthInfoWithOAuthAccessToken(with: oAuthTokenInfo)
+            .do(onSuccess: { authInfo in
+                let isSuccess = authInfo != nil
+                
+                Logger.log(
+                    message: """
+                    \(oAuthTokenInfo.loginType?.description ?? "") OAuth 로그인 성공 여부: \(isSuccess)
+                    (false일 경우 생성한 OAuth Access Token에 대한 회원 정보 없기 때문에 신규 가입 필요)
+                    """,
                     category: .authentication,
                     type: .debug
                 )
             })
-    }
-    
-    public func requestSignin(with userInfo: UserAuthInfoEntity) -> Observable<Bool> {
-        loginRepository.requestSignin(with: userInfo).asObservable()
-    }
-
-    public func saveUserInfo(_ userInfo: UserInfoEntity) -> Completable {
-        keyChainRepository
-            .saveObjectToKeyChain(userInfo, forKey: .userAuthInfo)
-            .concat(self.userDefaultsRepository.updateValue(for: .userNickname, with: userInfo.nickname))
-            .concat(self.userDefaultsRepository.updateValue(for: .userLoginType, with: userInfo.authInfo.loginType))
-            .logErrorIfDetected(category: .authentication)
-    }
-    
-    public func fetchAccessToken(for loginType: LoginType) -> Observable<UserAuthInfoEntity?> {
-        loginRepository.fetchAccessToken(for: loginType)
             .asObservable()
-            .map { UserAuthInfoEntity(loginType: loginType, accessToken: $0) }
+            .withLatestFrom(userInfoUseCase.userInfo) { (updatedAuthInfo: $0, originalUserInfo: $1) }
+            .flatMapLatest { updatedAuthInfo, originalUserInfo -> Observable<Bool> in
+                guard let updatedAuthInfo = updatedAuthInfo else {
+                    return .just(false)
+                }
+
+                let userInfoExists = originalUserInfo != nil
+                Logger.log(
+                    message: "KeyChain 내 회원정보 존재 확인: \(userInfoExists)",
+                    category: .authentication,
+                    type: .debug
+                )
+
+                if userInfoExists {
+                    return .just(true)
+                } else {
+                    return self.userInfoUseCase.refreshUserInfo(with: updatedAuthInfo)
+                }
+            }
+    }
+    
+    /** 소셜 로그인(Apple, Kakao) OAuth Access Token 요청*/
+    public func fetchOAuthAccessToken(for loginType: LoginType) -> Observable<OAuthTokenInfo?> {
+        loginRepository.fetchOAuthAccessToken(for: loginType)
+            .asObservable()
+            .map { OAuthTokenInfo(loginType: loginType, accessToken: $0) }
             .logErrorIfDetected(category: .authentication)
     }
     
-    public func clearUserAuthInfoIfNeeded() -> Completable {
+    public func clearUserAuthInfoIfLaunchedFirstly() -> Completable {
         isAppFirstlyLaunched
             .do(onNext: {
                 Logger.log(message: "앱 설치 후 최초 기동 여부 확인: \($0)", category: .authentication, type: .debug)
@@ -70,7 +106,7 @@ public final class DefaultLoginUseCase: LoginUseCase {
                 Logger.log(message: "KeyChain에서 사용자 인증 정보를 확인합니다.", category: .authentication, type: .debug)
             })
             .flatMapLatest { `self`, _ in
-                self.userInfo.catchAndReturn(nil)
+                self.userInfoUseCase.userInfo.catchAndReturn(nil)
             }
             .compactMap { $0 }
             .withUnretained(self)

--- a/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/DefaultLoginUseCase.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/DefaultLoginUseCase.swift
@@ -53,6 +53,7 @@ public final class DefaultLoginUseCase: LoginUseCase {
     public func requestLogin(with oAuthTokenInfo: OAuthTokenInfo) -> Observable<Bool> {
         loginRepository
             .requestAuthInfoWithOAuthAccessToken(with: oAuthTokenInfo)
+            .catchAndReturn(nil)
             .do(onSuccess: { authInfo in
                 let isSuccess = authInfo != nil
                 

--- a/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/DefaultLoginUseCase.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/DefaultLoginUseCase.swift
@@ -84,7 +84,7 @@ public final class DefaultLoginUseCase: LoginUseCase {
                 if userInfoExists {
                     return .just(true)
                 } else {
-                    return self.userInfoUseCase.refreshUserInfo(with: updatedAuthInfo)
+                    return self.userInfoUseCase.fetchUserInfo(with: updatedAuthInfo)
                 }
             }
     }

--- a/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/DefaultSignupUseCase.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/DefaultSignupUseCase.swift
@@ -91,32 +91,26 @@ public final class DefaultSignupUseCase: SignupUseCase {
         }
     }
     
+    public func createFormattedDateString(with dateString: String) -> String? {
+        
+        let inputDateFormatter = DateFormatter()
+        inputDateFormatter.dateFormat = "yyMMdd"
+        
+        let outputDateFormatter = DateFormatter()
+        outputDateFormatter.dateFormat = "yyyy-MM-dd"
+        
+        guard let inputDate = inputDateFormatter.date(from: dateString) else { return nil }
+        return outputDateFormatter.string(from: inputDate)
+    }
+    
     private func isLeapYear(_ year: Int) -> Bool {
         return (year % 4 == 0 && year % 100 != 0) || year % 400 == 0
     }
     
     private func getBirthdayInputValidation(_ input: String) -> Bool {
-        guard input.count == 6 else { return false }
+        let inputDateFormatter = DateFormatter()
+        inputDateFormatter.dateFormat = "yyyy-MM-dd"
         
-        let numbersSet = CharacterSet.decimalDigits
-        let inputCharacterSet = CharacterSet(charactersIn: input)
-        guard inputCharacterSet.isSubset(of: numbersSet) else { return false }
-        
-        guard let year = Int(input.prefix(2)),
-              let month = Int(input.dropFirst(2).prefix(2)),
-              let day = Int(input.suffix(2)) else { return false }
-        
-        let isLeap = isLeapYear(year + 2000)
-        
-        switch month {
-        case 1, 3, 5, 7, 8, 10, 12:
-            return day >= 1 && day <= 31
-        case 4, 6, 9, 11:
-            return day >= 1 && day <= 30
-        case 2:
-            return day >= 1 && day <= (isLeap ? 29 : 28)
-        default:
-            return false
-        }
+        return inputDateFormatter.date(from: input) != nil
     }
 }

--- a/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/DefaultSignupUseCase.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/DefaultSignupUseCase.swift
@@ -48,7 +48,7 @@ public final class DefaultSignupUseCase: SignupUseCase {
             .asObservable()
             .withUnretained(self)
             .flatMapLatest { `self`, authInfo in
-                self.userInfoUseCase.refreshUserInfo(with: authInfo)
+                self.userInfoUseCase.fetchUserInfo(with: authInfo)
                     .do(onNext: {
                         Logger.log(
                             message: "회원 가입 성공 : \($0)",

--- a/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/DefaultSignupUseCase.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/DefaultSignupUseCase.swift
@@ -20,10 +20,15 @@ import Utils
 public final class DefaultSignupUseCase: SignupUseCase {
     
     @Inject(SharedDIContainer.shared) private var nicknameUseCase: NicknameUseCase
+    @Inject(LoginDIContainer.shared) private var signupRepository: SignupRepository
     
     public init() { }
     
     private var essentialConditions: Set<AgreementCondition> = []
+    
+    public func requestSignup(_ signupInfo: SignupInput) -> Observable<Bool> {
+        signupRepository.requestSignup(with: signupInfo).asObservable()
+    }
     
     // TODO: Repository로 이동
     private let conditionEntities: [AgreementCondition] = [

--- a/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/DefaultSignupUseCase.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/DefaultSignupUseCase.swift
@@ -121,6 +121,7 @@ public final class DefaultSignupUseCase: SignupUseCase {
         }
     }
     
+    // TODO: 추후에 Utils에 구현된 부분으로 대체 가능한 지 확인 후 제거
     public func createFormattedDateString(with dateString: String) -> String? {
         
         let inputDateFormatter = DateFormatter()

--- a/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/DefaultSignupUseCase.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/DefaultSignupUseCase.swift
@@ -21,7 +21,7 @@ public final class DefaultSignupUseCase: SignupUseCase {
     
     @Inject(SharedDIContainer.shared) private var userInfoUseCase: UserInfoUseCase
     @Inject(SharedDIContainer.shared) private var nicknameUseCase: NicknameUseCase
-
+    
     @Inject(SharedDIContainer.shared) private var keyChainRepository: KeyChainRepository
     @Inject(SharedDIContainer.shared) private var userDefaultsRepository: UserDefaultsRepository
     @Inject(LoginDIContainer.shared) private var signupRepository: SignupRepository
@@ -138,9 +138,27 @@ public final class DefaultSignupUseCase: SignupUseCase {
     }
     
     private func getBirthdayInputValidation(_ input: String) -> Bool {
-        let inputDateFormatter = DateFormatter()
-        inputDateFormatter.dateFormat = "yyyy-MM-dd"
+        guard input.count == 6 else { return false }
         
-        return inputDateFormatter.date(from: input) != nil
+        let numbersSet = CharacterSet.decimalDigits
+        let inputCharacterSet = CharacterSet(charactersIn: input)
+        guard inputCharacterSet.isSubset(of: numbersSet) else { return false }
+        
+        guard let year = Int(input.prefix(2)),
+              let month = Int(input.dropFirst(2).prefix(2)),
+              let day = Int(input.suffix(2)) else { return false }
+        
+        let isLeap = isLeapYear(year + 2000)
+        
+        switch month {
+        case 1, 3, 5, 7, 8, 10, 12:
+            return day >= 1 && day <= 31
+        case 4, 6, 9, 11:
+            return day >= 1 && day <= 30
+        case 2:
+            return day >= 1 && day <= (isLeap ? 29 : 28)
+        default:
+            return false
+        }
     }
 }

--- a/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/Interface/LoginUseCase.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/Interface/LoginUseCase.swift
@@ -17,7 +17,7 @@ public protocol LoginUseCase {
     /** 현재 로컬 기기에 저장된 사용자 인증 정보로 자동 로그인 처리 요청 */
     func requestAutoLoginWithExistingUserInfo() -> Observable<Bool>
     /** OAuth 토큰 정보로 Lifepoo Access Token, Refresh Token 획득 및 로그인 처리 요청 */
-    func requestLogin(with userInfo: OAuthTokenInfo) -> Observable<Bool>
+    func requestLogin(with userInfo: OAuthTokenInfo) -> Observable<Result<Bool, LoginError>>
     /** 소셜 로그인(Apple, Kakao) OAuth Access Token 요청*/
     func fetchOAuthAccessToken(for loginType: LoginType) -> Observable<OAuthTokenInfo?>
 }

--- a/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/Interface/LoginUseCase.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/Interface/LoginUseCase.swift
@@ -11,9 +11,13 @@ import RxSwift
 import CoreEntity
 
 public protocol LoginUseCase {
-    var userInfo: Observable<UserInfoEntity?> { get }
-    func saveUserInfo(_ userInfo: UserInfoEntity) -> Completable
-    func requestSignin(with userInfo: UserAuthInfoEntity) -> Observable<Bool>
-    func fetchAccessToken(for loginType: LoginType) -> Observable<UserAuthInfoEntity?>
-    func clearUserAuthInfoIfNeeded() -> Completable
+
+    /** 앱 설치 후 최초 기동 시에 기존에 저장된 사용자 인증 정보 초기화*/
+    func clearUserAuthInfoIfLaunchedFirstly() -> Completable
+    /** 현재 로컬 기기에 저장된 사용자 인증 정보로 자동 로그인 처리 요청 */
+    func requestAutoLoginWithExistingUserInfo() -> Observable<Bool>
+    /** OAuth 토큰 정보로 Lifepoo Access Token, Refresh Token 획득 및 로그인 처리 요청 */
+    func requestLogin(with userInfo: OAuthTokenInfo) -> Observable<Bool>
+    /** 소셜 로그인(Apple, Kakao) OAuth Access Token 요청*/
+    func fetchOAuthAccessToken(for loginType: LoginType) -> Observable<OAuthTokenInfo?>
 }

--- a/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/Interface/SignupUseCase.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/Interface/SignupUseCase.swift
@@ -12,6 +12,7 @@ import CoreEntity
 
 public protocol SignupUseCase {
 
+    /** 사용자 입력 회원가입 정보로 서버에 새로운 회원정보 추가 요청 **/
     func requestSignup(_ signupInfo: SignupInput) -> Observable<Bool>
     func fetchSelectableConditions() -> Observable<[AgreementCondition]>
     func isNicknameInputValid(_ input: String) -> Observable<NicknameTextInput>

--- a/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/Interface/SignupUseCase.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/Interface/SignupUseCase.swift
@@ -11,9 +11,11 @@ import RxSwift
 import CoreEntity
 
 public protocol SignupUseCase {
-    
+
+    func requestSignup(_ signupInfo: SignupInput) -> Observable<Bool>
     func fetchSelectableConditions() -> Observable<[AgreementCondition]>
     func isNicknameInputValid(_ input: String) -> Observable<NicknameTextInput>
     func isBirthdayInputValid(_ input: String) -> Observable<BirthdayTextInput>
+    func createFormattedDateString(with dateString: String) -> String?
     func isAllEsssentialConditionsSelected(_ selectedConditions: Set<AgreementCondition>) -> Observable<Bool>
 }

--- a/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/LoginError.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/LoginError.swift
@@ -1,0 +1,33 @@
+//
+//  LoginError.swift
+//  FeatureLoginUseCase
+//
+//  Created by Lee, Joon Woo on 2023/10/05.
+//  Copyright © 2023 Lifepoo. All rights reserved.
+//
+
+import Foundation
+
+public enum LoginError: Error, CustomStringConvertible {
+    
+    case oAuthLoginFailed
+    case userNotExists
+    case failedFetchingUserInfo
+    case updatedAuthInfoNil
+    case otherNetworkError(error: Error)
+    
+    public var description: String {
+        switch self {
+        case .oAuthLoginFailed:
+            return "소셜 로그인 실패"
+        case .userNotExists:
+            return "해당 사용자가 존재하지 않음. 회원가입 필요"
+        case .failedFetchingUserInfo:
+            return "사용자 정보 불러오기 실패"
+        case .updatedAuthInfoNil:
+            return "업데이트된 인증정보가 존재하지 않음. Repository 리턴값 재확인 필요"
+        case .otherNetworkError(let error):
+            return "알 수 없는 네트워크 에러\n(\(error))"
+        }
+    }
+}

--- a/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/RepositoryInterface/LoginRepository.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/RepositoryInterface/LoginRepository.swift
@@ -13,6 +13,6 @@ import Utils
 
 public protocol LoginRepository: AnyObject {
     
-    func requestSignin(with userAuthInfo: UserAuthInfoEntity) -> Single<Bool>
-    func fetchAccessToken(for loginType: LoginType) -> Single<String>
+    func requestAuthInfoWithOAuthAccessToken(with userAuthInfo: OAuthTokenInfo) -> Single<UserAuthInfoEntity?>
+    func fetchOAuthAccessToken(for loginType: LoginType) -> Single<String>
 }

--- a/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/RepositoryInterface/LoginRepository.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/RepositoryInterface/LoginRepository.swift
@@ -13,6 +13,6 @@ import Utils
 
 public protocol LoginRepository: AnyObject {
     
-    func requestAuthInfoWithOAuthAccessToken(with userAuthInfo: OAuthTokenInfo) -> Single<UserAuthInfoEntity?>
+    func requestAuthInfoWithOAuthAccessToken(with userAuthInfo: OAuthTokenInfo) -> Single<Result<UserAuthInfoEntity?, LoginError>>
     func fetchOAuthAccessToken(for loginType: LoginType) -> Single<String>
 }

--- a/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/RepositoryInterface/SignupRepository.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/RepositoryInterface/SignupRepository.swift
@@ -13,5 +13,5 @@ import Utils
 
 public protocol SignupRepository: AnyObject {
     
-    func requestSignup(with signupInfo: SignupInput) -> Single<Bool>
+    func requestSignup(with signupInput: SignupInput) -> Single<UserAuthInfoEntity>
 }

--- a/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/RepositoryInterface/SignupRepository.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/RepositoryInterface/SignupRepository.swift
@@ -6,4 +6,12 @@
 //  Copyright © 2023 Lifepoo. All rights reserved.
 //
 
-import Foundation
+import RxSwift
+
+import CoreEntity
+import Utils
+
+public protocol SignupRepository: AnyObject {
+    
+    func requestSignup(with signupInfo: SignupInput) -> Single<Bool>
+}

--- a/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/RepositoryInterface/SignupRepository.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/RepositoryInterface/SignupRepository.swift
@@ -1,0 +1,9 @@
+//
+//  SignupRepository.swift
+//  FeatureLoginUseCase
+//
+//  Created by Lee, Joon Woo on 2023/09/26.
+//  Copyright © 2023 Lifepoo. All rights reserved.
+//
+
+import Foundation

--- a/Projects/Logger/Sources/OSLog+LogCategory.swift
+++ b/Projects/Logger/Sources/OSLog+LogCategory.swift
@@ -21,6 +21,7 @@ public extension OSLog {
         case bundle
         case network
         case database
+        case keyChain
         case authentication
         
         var value: String {
@@ -37,6 +38,8 @@ public extension OSLog {
                 return Constant.OSLogCategory.network
             case .database:
                 return Constant.OSLogCategory.database
+            case .keyChain:
+                return Constant.OSLogCategory.keyChain
             case .authentication:
                 return Constant.OSLogCategory.authentication
             }

--- a/Projects/Shared/SharedRepository/Sources/DefaultUserInfoRepository.swift
+++ b/Projects/Shared/SharedRepository/Sources/DefaultUserInfoRepository.swift
@@ -85,7 +85,7 @@ public final class DefaultUserInfoRepository: UserInfoRepository {
                     
                     throw NetworkError.dataMappingError
                 }
-                
+                // TODO: Mapper 사용하도록 수정
                 return UserInfoEntity(
                     userId: dto.id,
                     nickname: dto.nickname,

--- a/Projects/Shared/SharedRepository/Sources/DefaultUserInfoRepository.swift
+++ b/Projects/Shared/SharedRepository/Sources/DefaultUserInfoRepository.swift
@@ -1,0 +1,120 @@
+//
+//  DefaultUserInfoRepository.swift
+//  SharedRepository
+//
+//  Created by Lee, Joon Woo on 2023/10/01.
+//  Copyright © 2023 Lifepoo. All rights reserved.
+//
+
+import Foundation
+
+import CoreDIContainer
+import CoreEntity
+import CoreNetworkService
+import Logger
+import RxSwift
+import SharedUseCase
+import Utils
+
+public final class DefaultUserInfoRepository: UserInfoRepository {
+    
+    @Inject(CoreDIContainer.shared) private var urlSessionEndpointService: EndpointService
+    
+    public init() { }
+    
+    /** Refresh Token으로 서버로부터 Access Token, Refresh Token 업데이트 */
+    public func requestRefreshingUserAuthInfo(
+        with authInfo: UserAuthInfoEntity
+    ) -> Single<UserAuthInfoEntity?> {
+        urlSessionEndpointService
+            .fetchNetworkResult(
+                endpoint: LifePoopLocalTarget.updateAccessToken(
+                    refreshToken: authInfo.refreshToken
+                )
+            )
+            .logErrorIfDetected(category: .network)
+            .asObservable()
+            .withUnretained(self)
+            .map { `self`, networkResult -> UserAuthInfoEntity? in
+                let statusCode = networkResult.statusCode
+                let responseData = String(data: networkResult.data ?? Data(), encoding: .utf8) ?? ""
+                let url = networkResult.response.url?.absoluteString ?? ""
+                guard statusCode >= 200 && statusCode < 300 else {
+                    
+                    Logger.log(
+                        message: "토큰 업데이트 요청 에러:\n\(url)\n\(responseData)",
+                        category: .network,
+                        type: .error
+                    )
+                    
+                    throw NetworkError.invalidStatusCode(code: statusCode)
+                }
+                
+                var accessToken: String?
+                var refreshToken: String?
+                
+                // MARK: AccessToken 추출
+                if let bodyData = networkResult.data {
+                    let body = try JSONDecoder().decode([String: String].self, from: bodyData)
+                    accessToken = body["accessToken"]
+                }
+                
+                // MARK: RefreshToken 추출
+                if let cookies = networkResult.cookies {
+                    refreshToken = cookies["refresh_token"]
+                }
+                
+                return self.createUpdatedUserAuthInfo(
+                    accessToken: accessToken,
+                    refreshToken: refreshToken,
+                    loginType: authInfo.loginType
+                )
+            }
+            .asSingle()
+    }
+    
+    /** 전달된 refresh tokenm, access token으로 서버로부터 해당되는 사용자 정보 요청 */
+    public func fetchUserInfo(with authInfo: UserAuthInfoEntity) -> Single<UserInfoEntity?> {
+        urlSessionEndpointService
+            .fetchData(endpoint: LifePoopLocalTarget.fetchUserInfo(accessToken: authInfo.accessToken))
+            .decodeMap(UserInfoDTO.self)
+            .map { dto in
+                guard let genderType = GenderType(stringValue: dto.sex),
+                      let profileColor = StoolColor(rawValue: dto.characterColor - 1),
+                      let profileShape = StoolShape(rawValue: dto.characterShape - 1) else {
+                    
+                    throw NetworkError.dataMappingError
+                }
+                
+                return UserInfoEntity(
+                    userId: dto.id,
+                    nickname: dto.nickname,
+                    birthDate: dto.birth,
+                    genderType: genderType,
+                    profileCharacter: ProfileCharacter(color: profileColor, shape: profileShape),
+                    invitationCode: dto.inviteCode,
+                    authInfo: authInfo
+                )
+            }
+            .logErrorIfDetected(category: .network, type: .error)
+    }
+}
+
+private extension DefaultUserInfoRepository {
+    
+    func createUpdatedUserAuthInfo(
+        accessToken: String?,
+        refreshToken: String?,
+        loginType: LoginType?
+    ) -> UserAuthInfoEntity? {
+        guard let accessToken = accessToken,
+              let refreshToken = refreshToken,
+              let loginType = loginType else { return nil }
+        
+        return UserAuthInfoEntity(
+            loginType: loginType,
+            accessToken: accessToken,
+            refreshToken: refreshToken
+        )
+    }
+}

--- a/Projects/Shared/SharedUseCase/Sources/DefaultUserInfoUseCase.swift
+++ b/Projects/Shared/SharedUseCase/Sources/DefaultUserInfoUseCase.swift
@@ -97,7 +97,7 @@ public final class DefaultUserInfoUseCase: UserInfoUseCase {
             }
     }
     
-    public func refreshUserInfo(with authInfo: UserAuthInfoEntity) -> Observable<Bool> {
+    public func fetchUserInfo(with authInfo: UserAuthInfoEntity) -> Observable<Bool> {
         userInfoRepository.fetchUserInfo(with: authInfo)
             .asObservable()
             .withUnretained(self)

--- a/Projects/Shared/SharedUseCase/Sources/DefaultUserInfoUseCase.swift
+++ b/Projects/Shared/SharedUseCase/Sources/DefaultUserInfoUseCase.swift
@@ -159,7 +159,7 @@ private extension DefaultUserInfoUseCase {
         )
         
         return keyChainRepository
-            .removeObjectFromKeyChain(userInfo, forKey: .userAuthInfo)
+            .removeObjectFromKeyChain(forKey: .userAuthInfo)
             .concat(userDefaultsRepository.removeValue(for: .userNickname))
             .concat(userDefaultsRepository.removeValue(for: .userLoginType))
             .concat(userDefaultsRepository.removeValue(for: .profileCharacter))

--- a/Projects/Shared/SharedUseCase/Sources/DefaultUserInfoUseCase.swift
+++ b/Projects/Shared/SharedUseCase/Sources/DefaultUserInfoUseCase.swift
@@ -1,0 +1,167 @@
+//
+//  DefaultUserInfoUseCase.swift
+//  SharedUseCase
+//
+//  Created by Lee, Joon Woo on 2023/10/01.
+//  Copyright © 2023 Lifepoo. All rights reserved.
+//
+
+import Foundation
+
+import CoreEntity
+import Logger
+import RxSwift
+import SharedDIContainer
+import Utils
+
+public final class DefaultUserInfoUseCase: UserInfoUseCase {
+    
+    enum UserInfoError: Error {
+        case refreshingTokenFailed
+        case refreshingUserInfoFailed
+    }
+    
+    @Inject(SharedDIContainer.shared) private var keyChainRepository: KeyChainRepository
+    @Inject(SharedDIContainer.shared) private var userDefaultsRepository: UserDefaultsRepository
+    @Inject(SharedDIContainer.shared) private var userInfoRepository: UserInfoRepository
+    
+    public init() { }
+    
+    public var userInfo: Observable<UserInfoEntity?> {
+        keyChainRepository
+            .getObjectFromKeyChain(
+                asTypeOf: UserInfoEntity.self,
+                forKey: .userAuthInfo,
+                handleExceptionWhenValueNotFound: false
+            )
+            .logErrorIfDetected(category: .authentication)
+            .catchAndReturn(nil)
+            .asObservable()
+            .do(onNext: { userInfo in
+                let nickname = userInfo?.nickname ?? "nil"
+                let loginType = userInfo?.authInfo.loginType?.rawValue ?? "nil"
+                Logger.log(
+                    message: "KeyChain 사용자 정보 확인: \(nickname), 로그인 유형: \(loginType)",
+                    category: .authentication,
+                    type: .debug
+                )
+            })
+    }
+    
+    public func refreshAuthInfo(with authInfo: UserAuthInfoEntity) -> Observable<Bool> {
+        userInfoRepository.requestRefreshingUserAuthInfo(with: authInfo)
+            .do(onSuccess: { updatedAuthInfo in
+                Logger.log(
+                    message: "서버로부터 인증정보 업데이트 성공: \(updatedAuthInfo != nil)",
+                    category: .authentication,
+                    type: .debug
+                )
+            }, onError: { error in
+                Logger.log(
+                    message: "서버로부터 인증정보 업데이트 실패 : \(error)",
+                    category: .authentication,
+                    type: .error
+                )
+            })
+            .asObservable()
+            .withLatestFrom(userInfo) { (updatedAuthInfo: $0, originalUserInfo: $1) }
+            .map { updatedAuthInfo, originalUserInfo in
+                guard let updatedAuthInfo = updatedAuthInfo,
+                      let originalUserInfo = originalUserInfo else {
+                    
+                    throw UserInfoError.refreshingTokenFailed
+                }
+                
+                return UserInfoEntity(
+                    userId: originalUserInfo.userId,
+                    nickname: originalUserInfo.nickname,
+                    birthDate: originalUserInfo.birthDate,
+                    genderType: originalUserInfo.genderType,
+                    profileCharacter: originalUserInfo.profileCharacter,
+                    invitationCode: originalUserInfo.invitationCode,
+                    authInfo: updatedAuthInfo
+                )
+            }
+            .withUnretained(self)
+            .flatMap { `self`, updatedUserInfo in
+                self.saveUserInfo(updatedUserInfo)
+                    .andThen(Observable.just(true))
+                    .catchAndReturn(false)
+            }
+            .catch { [weak self] _ in
+                guard let `self` = self else {
+                    return Observable.just(false)
+                }
+                
+                return self.clearUserInfoIfNeeded()
+            }
+    }
+    
+    public func refreshUserInfo(with authInfo: UserAuthInfoEntity) -> Observable<Bool> {
+        userInfoRepository.fetchUserInfo(with: authInfo)
+            .asObservable()
+            .withUnretained(self)
+            .flatMapLatest { `self`, userInfo in
+                guard let userInfo = userInfo else {
+                    return Observable<Bool>.error(UserInfoError.refreshingUserInfoFailed)
+                }
+                
+                return self.saveUserInfo(userInfo)
+                    .andThen(Observable.just(true))
+                    .catch { Observable.error($0) }
+            }
+    }
+}
+
+private extension DefaultUserInfoUseCase {
+    
+    func clearUserInfoIfNeeded() -> Observable<Bool> {
+        userInfo
+            .withUnretained(self)
+            .flatMap { `self`, userInfo in
+                self.removeUserInfo(userInfo)
+                    .andThen(Observable.just(false))
+            }
+    }
+    
+    func saveUserInfo(_ userInfo: UserInfoEntity) -> Completable {
+        
+        Logger.log(
+            message: """
+            업데이트된 사용자 정보 KeyChain에 저장
+            nickname: \(userInfo.nickname), loginType: \(userInfo.authInfo.loginType?.description ?? "")
+            """,
+            category: .authentication,
+            type: .debug
+        )
+        
+        return keyChainRepository
+            .saveObjectToKeyChain(userInfo, forKey: .userAuthInfo)
+            .concat(userDefaultsRepository.updateValue(for: .userNickname, with: userInfo.nickname))
+            .concat(userDefaultsRepository.updateValue(for: .userLoginType, with: userInfo.authInfo.loginType))
+            .concat(userDefaultsRepository.updateValue(for: .profileCharacter, with: userInfo.profileCharacter))
+            .logErrorIfDetected(category: .authentication)
+    }
+    
+    func removeUserInfo(_ userInfo: UserInfoEntity?) -> Completable {
+        guard let userInfo = userInfo else {
+            return .empty()
+        }
+        
+        Logger.log(
+            message: """
+            기존 사용자정보 제거
+            nickname: \(userInfo.nickname)
+            loginType: \(userInfo.authInfo.loginType?.description ?? "")
+            """,
+            category: .authentication,
+            type: .debug
+        )
+        
+        return keyChainRepository
+            .removeObjectFromKeyChain(userInfo, forKey: .userAuthInfo)
+            .concat(userDefaultsRepository.removeValue(for: .userNickname))
+            .concat(userDefaultsRepository.removeValue(for: .userLoginType))
+            .concat(userDefaultsRepository.removeValue(for: .profileCharacter))
+    }
+}

--- a/Projects/Shared/SharedUseCase/Sources/Interface/UserInfoUseCase.swift
+++ b/Projects/Shared/SharedUseCase/Sources/Interface/UserInfoUseCase.swift
@@ -1,0 +1,22 @@
+//
+//  UserInfoUseCase.swift
+//  SharedUseCase
+//
+//  Created by Lee, Joon Woo on 2023/10/01.
+//  Copyright © 2023 Lifepoo. All rights reserved.
+//
+
+import Foundation
+
+import CoreEntity
+import RxSwift
+
+public protocol UserInfoUseCase: AnyObject {
+    
+    /** 기기에 저장된 사용자 정보 조회*/
+    var userInfo: Observable<UserInfoEntity?> { get }
+    /** 기존 사용자 인증 정보 업데이트(서버 동기화)*/
+    func refreshAuthInfo(with authInfo: UserAuthInfoEntity) -> Observable<Bool>
+    /** 기존 사용자 정보 업데이트(서버 동기화)*/
+    func refreshUserInfo(with authInfo: UserAuthInfoEntity) -> Observable<Bool>
+}

--- a/Projects/Shared/SharedUseCase/Sources/Interface/UserInfoUseCase.swift
+++ b/Projects/Shared/SharedUseCase/Sources/Interface/UserInfoUseCase.swift
@@ -18,5 +18,5 @@ public protocol UserInfoUseCase: AnyObject {
     /** 기존 사용자 인증 정보 업데이트(서버 동기화)*/
     func refreshAuthInfo(with authInfo: UserAuthInfoEntity) -> Observable<Bool>
     /** 기존 사용자 정보 업데이트(서버 동기화)*/
-    func refreshUserInfo(with authInfo: UserAuthInfoEntity) -> Observable<Bool>
+    func fetchUserInfo(with authInfo: UserAuthInfoEntity) -> Observable<Bool>
 }

--- a/Projects/Shared/SharedUseCase/Sources/RepositoryInterface/KeyChainRepository.swift
+++ b/Projects/Shared/SharedUseCase/Sources/RepositoryInterface/KeyChainRepository.swift
@@ -32,7 +32,11 @@ public protocol KeyChainRepository: AnyObject {
         forKey key: ItemKey,
         handleExceptionWhenValueNotFound: Bool
     ) -> Single<T?>
-    func removeObjectFromKeyChain<T: Encodable>(_ object: T, forKey key: ItemKey) -> Completable
+    func getBinaryDataFromKeyChain(
+        forKey key: ItemKey,
+        handleExceptionWhenValueNotFound: Bool
+    ) -> Single<Data?>
+    func removeObjectFromKeyChain(forKey key: ItemKey) -> Completable
 }
 
 public extension KeyChainRepository {

--- a/Projects/Shared/SharedUseCase/Sources/RepositoryInterface/KeyChainRepository.swift
+++ b/Projects/Shared/SharedUseCase/Sources/RepositoryInterface/KeyChainRepository.swift
@@ -27,6 +27,25 @@ public enum KeyChainAction {
 public protocol KeyChainRepository: AnyObject {
     
     func saveObjectToKeyChain<T: Codable>(_ object: T, forKey key: ItemKey) -> Completable
-    func getObjectFromKeyChain<T: Decodable>(asTypeOf targetType: T.Type, forKey key: ItemKey) -> Single<T?>
+    func getObjectFromKeyChain<T: Decodable>(
+        asTypeOf targetType: T.Type,
+        forKey key: ItemKey,
+        handleExceptionWhenValueNotFound: Bool
+    ) -> Single<T?>
     func removeObjectFromKeyChain<T: Encodable>(_ object: T, forKey key: ItemKey) -> Completable
+}
+
+public extension KeyChainRepository {
+    
+    func getObjectFromKeyChain<T: Decodable>(
+        asTypeOf targetType: T.Type,
+        forKey key: ItemKey,
+        handleExceptionWhenValueNotFound: Bool = true
+    ) -> Single<T?> {
+        getObjectFromKeyChain(
+            asTypeOf: targetType,
+            forKey: key,
+            handleExceptionWhenValueNotFound: handleExceptionWhenValueNotFound
+        )
+    }
 }

--- a/Projects/Shared/SharedUseCase/Sources/RepositoryInterface/UserInfoRepository.swift
+++ b/Projects/Shared/SharedUseCase/Sources/RepositoryInterface/UserInfoRepository.swift
@@ -1,0 +1,21 @@
+//
+//  UserInfoRepository.swift
+//  SharedUseCase
+//
+//  Created by Lee, Joon Woo on 2023/10/01.
+//  Copyright © 2023 Lifepoo. All rights reserved.
+//
+
+import Foundation
+
+import CoreEntity
+import RxSwift
+
+public protocol UserInfoRepository: AnyObject {
+    
+    /** refresh token으로 서버로부터 access token, refresh token 업데이트 */
+    func requestRefreshingUserAuthInfo(with authInfo: UserAuthInfoEntity) -> Single<UserAuthInfoEntity?>
+    
+    /** 전달된 refresh tokenm, access token으로 서버로부터 해당되는 사용자 정보 요청 */
+    func fetchUserInfo(with authInfo: UserAuthInfoEntity) -> Single<UserInfoEntity?>
+}

--- a/Projects/Utils/Sources/Constant/Constant.swift
+++ b/Projects/Utils/Sources/Constant/Constant.swift
@@ -42,6 +42,7 @@ public extension Constant {
         public static let userDefaults = "UserDefaults"
         public static let network = "Network"
         public static let database = "Database"
+        public static let keyChain = "KeyChain"
         public static let authentication = "Authentication"
     }
 }

--- a/Projects/Utils/Sources/Extension/Date+localizedString.swift
+++ b/Projects/Utils/Sources/Extension/Date+localizedString.swift
@@ -9,6 +9,13 @@
 import Foundation
 
 public extension Date {
+    /// 'yyyy-MM-dd' 형태의 `String` 타입으로 변환합니다. (시간은 포함되지 않습니다.)
+    ///
+    /// 예) "2023-06-21"
+    var dateString: String { // TODO: Rename
+        return LifePoopDateFormatter.shared.convertDateToString(from: self)
+    }
+    
     /// 현지화된 long 스타일의 `String` 타입으로 변환합니다. (시간은 포함되지 않습니다.)
     ///
     /// 예) "2023년 6월 21일"

--- a/Projects/Utils/Sources/Support/LifePoopDateFormatter.swift
+++ b/Projects/Utils/Sources/Support/LifePoopDateFormatter.swift
@@ -37,6 +37,11 @@ final class LifePoopDateFormatter {
         return formatter
     }()
     
+    func convertDateToString(from date: Date) -> String {
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        return dateFormatter.string(from: date)
+    }
+    
     func convertDateToLocalizedString(
         from date: Date,
         dateStyle: DateFormatter.Style,


### PR DESCRIPTION
### 🔖 관련 이슈
- #80 

<br> 

### ⚒️ 작업 내역

- [x] 앱 기동 후 로그인 처리 과정 수정
- [x] 서버 API 명세에 맞춰서 DTO 구현
- [x] 회원가입 처리

<br>

### 💻 리뷰어 가이드
> 원활한 확인을 위해 시뮬레이터 환경(실기기는 우선 보류) 기존에 설치된 앱은 삭제하고 아래 순서대로 진행해주세요..!
1. (회원가입 안한상태에서) `앱 설치 > 소셜 로그인 > 회원 가입 > 홈 화면` 순서대로 진입 확인
2. (회원가입 성공 상태에서) `기존에 설치한 앱 재실행 > 홈 화면` 순서대로 진입 확인 (자동 로그인)
3. (회원가입 성공 상태에서) `기존 앱 삭제 > 다시 앱 설치 > 소셜 로그인 > 홈 화면` 순서대로 진입 확인

** 콘솔창에 로그 찍어놔서 이거 보고 확인하셔도 됩니다. 자세한건 회의할 때 한번 다시 리뷰할께요!
<br>

### 📝 부가 설명
- 소셜 로그인(카카오, 애플 토큰 요청), 로그인 처리, 회원가입 처리 총 3가지 구현했습니다.
- UserInfoUseCase 기존에 공통으로 사용하던거 다시 살렸는데(괜히 지웠다가 번거롭게 했네요 죄송해요 ㅠ), 다시 필요한 부분에서 사용하시면 됩니다..
- 로그인 및 회원가입 순서를 아래처럼 했는데, 혹시 순서 보시고 어색하거나 개선 필요한 부분 있으면 말씀해주세요..! 사실 하다보니까 조금 복잡해지기도 하고, 저도 좀 미흡하게 했다 싶어서 ㅠ 우리끼리 한 번 논의했으면 좋겠어요..
    - 회원가입 요청 -> 정상 응답 확인 -> 응답값에 포함된 토큰값 확인 -> 해당 토큰으로 유저정보 GET 요청 -> 유저정보 정상 확인되면, 해당 정보 키체인에 저장
    - (비로그인 상태에서) 로그인 요청 -> 정상 응답되면 응답값에 있는 토큰값으로 업데이트 -> 해당 토큰값으로 유저정보 요청 -> 정상 응답되면 해당 유저정보 키체인에 저장
    - 앱 기동 시 키체인에 있는 유저정보 확인 -> 토큰 refresh 요청 -> 정상 응답되면 응답값에 있는 인증정보를 포함하는 유저정보를 키체인에 저장