### PR TITLE
친구 목록 조회, 초대 코드 입력 및 공유 API 연동

### DIFF
--- a/Projects/App/Sources/SceneDelegate.swift
+++ b/Projects/App/Sources/SceneDelegate.swift
@@ -103,6 +103,7 @@ private extension SceneDelegate {
     func registerCoreDependencies() {
         CoreDIContainer.shared.register(service: AnyDataMapper.self) { AnyDataMapper(StoolLogEntityMapper()) }
         CoreDIContainer.shared.register(service: AnyDataMapper.self) { AnyDataMapper(StoolLogDTOMapper()) }
+        CoreDIContainer.shared.register(service: AnyDataMapper.self) { AnyDataMapper(FriendEntityMapper()) }
         CoreDIContainer.shared.register(service: EndpointService.self) { URLSessionEndpointService.shared }
         CoreDIContainer.shared.register(service: DiskCacheStorage.self) { FileManagerDiskCacheStorage.shared }
         CoreDIContainer.shared.register(service: MemoryCacheStorage.self) { NSCacheMemoryCacheStorage.shared }

--- a/Projects/Core/CoreEntity/Sources/FriendEntity.swift
+++ b/Projects/Core/CoreEntity/Sources/FriendEntity.swift
@@ -9,12 +9,23 @@
 import Foundation
 
 public struct FriendEntity {
-    public let name: String
+    public let id: Int
+    public let nickname: String
+    // TODO: 스토리 API 최종 구현 후 해당 속성 어떻게 할 지 다시 확인
     public var isActivated: Bool
     public let profile: ProfileCharacter
     
-    public init(name: String, isActivated: Bool, profile: ProfileCharacter) {
-        self.name = name
+    public init(id: Int, nickname: String, isActivated: Bool, profile: ProfileCharacter) {
+        self.id = 1
+        self.nickname = nickname
+        self.isActivated = isActivated
+        self.profile = profile
+    }
+    
+    // FIXME: API 연동 후 더미데이터 제거해야 함
+    public init(nickname: String, isActivated: Bool, profile: ProfileCharacter) {
+        self.id = 1
+        self.nickname = nickname
         self.isActivated = isActivated
         self.profile = profile
     }
@@ -25,21 +36,21 @@ extension FriendEntity: Hashable { }
 extension FriendEntity {
     public static var dummyData: [FriendEntity] {
         return [
-            FriendEntity(name: "김유빈", isActivated: true, profile: .init(color: .brown, shape: .soft)),
-            FriendEntity(name: "이화정", isActivated: false, profile: .init(color: .brown, shape: .good)),
-            FriendEntity(name: "이준우", isActivated: true, profile: .init(color: .brown, shape: .hard)),
-            FriendEntity(name: "강시온", isActivated: false, profile: .init(color: .black, shape: .soft)),
-            FriendEntity(name: "손혜정", isActivated: true, profile: .init(color: .black, shape: .good)),
-            FriendEntity(name: "김상혁", isActivated: false, profile: .init(color: .black, shape: .hard)),
-            FriendEntity(name: "강시온가나", isActivated: true, profile: .init(color: .pink, shape: .soft)),
-            FriendEntity(name: "김상혁다라", isActivated: false, profile: .init(color: .pink, shape: .good)),
-            FriendEntity(name: "손혜정마바", isActivated: true, profile: .init(color: .pink, shape: .hard)),
-            FriendEntity(name: "김유빈사아", isActivated: false, profile: .init(color: .green, shape: .soft)),
-            FriendEntity(name: "이준우자차", isActivated: true, profile: .init(color: .green, shape: .good)),
-            FriendEntity(name: "이화정카타", isActivated: false, profile: .init(color: .green, shape: .hard)),
-            FriendEntity(name: "라이푸12", isActivated: false, profile: .init(color: .yellow, shape: .soft)),
-            FriendEntity(name: "LFPOO", isActivated: true, profile: .init(color: .yellow, shape: .good)),
-            FriendEntity(name: "12345", isActivated: true, profile: .init(color: .yellow, shape: .hard))
+            FriendEntity(nickname: "김유빈", isActivated: true, profile: .init(color: .brown, shape: .soft)),
+            FriendEntity(nickname: "이화정", isActivated: false, profile: .init(color: .brown, shape: .good)),
+            FriendEntity(nickname: "이준우", isActivated: true, profile: .init(color: .brown, shape: .hard)),
+            FriendEntity(nickname: "강시온", isActivated: false, profile: .init(color: .black, shape: .soft)),
+            FriendEntity(nickname: "손혜정", isActivated: true, profile: .init(color: .black, shape: .good)),
+            FriendEntity(nickname: "김상혁", isActivated: false, profile: .init(color: .black, shape: .hard)),
+            FriendEntity(nickname: "강시온가나", isActivated: true, profile: .init(color: .pink, shape: .soft)),
+            FriendEntity(nickname: "김상혁다라", isActivated: false, profile: .init(color: .pink, shape: .good)),
+            FriendEntity(nickname: "손혜정마바", isActivated: true, profile: .init(color: .pink, shape: .hard)),
+            FriendEntity(nickname: "김유빈사아", isActivated: false, profile: .init(color: .green, shape: .soft)),
+            FriendEntity(nickname: "이준우자차", isActivated: true, profile: .init(color: .green, shape: .good)),
+            FriendEntity(nickname: "이화정카타", isActivated: false, profile: .init(color: .green, shape: .hard)),
+            FriendEntity(nickname: "라이푸12", isActivated: false, profile: .init(color: .yellow, shape: .soft)),
+            FriendEntity(nickname: "LFPOO", isActivated: true, profile: .init(color: .yellow, shape: .good)),
+            FriendEntity(nickname: "12345", isActivated: true, profile: .init(color: .yellow, shape: .hard))
         ]
     }
 }

--- a/Projects/Core/CoreNetworkService/Sources/DTO/FriendDTO.swift
+++ b/Projects/Core/CoreNetworkService/Sources/DTO/FriendDTO.swift
@@ -1,0 +1,20 @@
+//
+//  FriendDTO.swift
+//  CoreNetworkService
+//
+//  Created by Lee, Joon Woo on 2023/10/15.
+//  Copyright © 2023 Lifepoo. All rights reserved.
+//
+
+import Foundation
+
+public struct FriendDTO: Codable {
+    
+    public let id: Int
+    public let nickname: String
+    public let birth: String
+    public let sex: String
+    public let characterColor: Int
+    public let characterShape: Int
+}
+

--- a/Projects/Core/CoreNetworkService/Sources/DataMapper/FriendEntityMapper.swift
+++ b/Projects/Core/CoreNetworkService/Sources/DataMapper/FriendEntityMapper.swift
@@ -1,0 +1,33 @@
+//
+//  FriendEntityMapper.swift
+//  CoreNetworkService
+//
+//  Created by Lee, Joon Woo on 2023/10/15.
+//  Copyright © 2023 Lifepoo. All rights reserved.
+//
+
+import Foundation
+
+import CoreEntity
+import Utils
+
+public struct FriendEntityMapper: DataMapper {
+    public init() { }
+    
+    public func transform(_ dto: FriendDTO) throws -> FriendEntity {
+        guard let profileColor = StoolColor(rawValue: dto.characterColor - 1),
+              let profileShape = StoolShape(rawValue: dto.characterShape - 1) else {
+            throw NetworkError.dataMappingError
+        }
+        
+        let profile = ProfileCharacter(color: profileColor, shape: profileShape)
+
+        // MARK: 1차 배포 시점에 하이라이팅 안하기 때문에 우선 false로 하드코딩
+        return FriendEntity(
+            id: dto.id,
+            nickname: dto.nickname,
+            isActivated: false,
+            profile: profile
+        )
+    }
+}

--- a/Projects/Core/CoreNetworkService/Sources/Error/NetworkError.swift
+++ b/Projects/Core/CoreNetworkService/Sources/Error/NetworkError.swift
@@ -16,6 +16,7 @@ public enum NetworkError: LocalizedError {
     case invalidStatusCode(code: Int)
     case invalidResponseData
     case invalidRequest
+    case invalidAccessToken
     case decodeError
     case encodeError
     case dataMappingError
@@ -35,6 +36,8 @@ public enum NetworkError: LocalizedError {
             return "Invalid status code: \(code)"
         case .invalidResponseData:
             return "Invalid response data."
+        case .invalidAccessToken:
+            return "Invalid access token"
         case .invalidRequest:
             return "Invalid request."
         case .decodeError:

--- a/Projects/Core/CoreNetworkService/Sources/Service/URLSessionEndpointService.swift
+++ b/Projects/Core/CoreNetworkService/Sources/Service/URLSessionEndpointService.swift
@@ -27,7 +27,7 @@ public final class URLSessionEndpointService: EndpointService {
             .map { $0.statusCode }
     }
     
-    public func fetchNetworkResult<E>(endpoint: TargetType, with bodyObject: E) -> Single<NetworkResult> where E : Encodable {
+    public func fetchNetworkResult<E: Encodable>(endpoint: TargetType, with bodyObject: E) -> Single<NetworkResult> {
         return performRequest(endpoint: endpoint, bodyObject: bodyObject)
     }
 }

--- a/Projects/Core/CoreNetworkService/Sources/Target/LifePoopLocalTarget.swift
+++ b/Projects/Core/CoreNetworkService/Sources/Target/LifePoopLocalTarget.swift
@@ -13,6 +13,7 @@ public enum LifePoopLocalTarget {
     case updateAccessToken(refreshToken: String)
     case signup(provider: String)
     case fetchUserInfo(accessToken: String)
+    case fetchFriendList(accessToken: String)
     case fetchStoolLog(userID: Int)
     case postStoolLog(accessToken: String)
     case sendInvitationCode(code: String, accessToken: String)
@@ -39,6 +40,8 @@ extension LifePoopLocalTarget: TargetType {
             return "/post"
         case .fetchUserInfo:
             return "/user"
+        case .fetchFriendList:
+            return "/user/friendship"
         case .sendInvitationCode(let code, _):
             return "/user/friendship/\(code)"
         }
@@ -46,7 +49,7 @@ extension LifePoopLocalTarget: TargetType {
     
     public var method: HTTPMethod {
         switch self {
-        case .fetchStoolLog, .fetchUserInfo:
+        case .fetchStoolLog, .fetchUserInfo, .fetchFriendList:
             return .get
         case .postStoolLog, .login, .signup, .updateAccessToken, .sendInvitationCode:
             return .post
@@ -55,7 +58,11 @@ extension LifePoopLocalTarget: TargetType {
     
     public var headers: [String: String]? {
         switch self {
-        case .postStoolLog(let accessToken), .fetchUserInfo(let accessToken), .sendInvitationCode(_, let accessToken):
+        case .postStoolLog(let accessToken),
+             .fetchUserInfo(let accessToken),
+             .sendInvitationCode(_, let accessToken),
+             .fetchFriendList(let accessToken)
+            :
             return [
                 "Content-Type": "application/json",
                 "Accept": "application/json",

--- a/Projects/Core/CoreNetworkService/Sources/Target/LifePoopLocalTarget.swift
+++ b/Projects/Core/CoreNetworkService/Sources/Target/LifePoopLocalTarget.swift
@@ -15,13 +15,14 @@ public enum LifePoopLocalTarget {
     case fetchUserInfo(accessToken: String)
     case fetchStoolLog(userID: Int)
     case postStoolLog(accessToken: String)
+    case sendInvitationCode(code: String, accessToken: String)
 }
 
 extension LifePoopLocalTarget: TargetType {
     public var baseURL: URL? {
         // MARK: 실서버 요청 확인할 경우 아래 url로 사용
-//        URL(string: "https://api.lifepoo.link")
-        URL(string: "http://localhost:3000")
+        URL(string: "https://api.lifepoo.link")
+//        URL(string: "http://localhost:3000")
     }
     
     public var path: String {
@@ -38,6 +39,8 @@ extension LifePoopLocalTarget: TargetType {
             return "/post"
         case .fetchUserInfo:
             return "/user"
+        case .sendInvitationCode(let code, _):
+            return "/user/friendship/\(code)"
         }
     }
     
@@ -45,14 +48,14 @@ extension LifePoopLocalTarget: TargetType {
         switch self {
         case .fetchStoolLog, .fetchUserInfo:
             return .get
-        case .postStoolLog, .login, .signup, .updateAccessToken:
+        case .postStoolLog, .login, .signup, .updateAccessToken, .sendInvitationCode:
             return .post
         }
     }
     
     public var headers: [String: String]? {
         switch self {
-        case .postStoolLog(let accessToken), .fetchUserInfo(let accessToken):
+        case .postStoolLog(let accessToken), .fetchUserInfo(let accessToken), .sendInvitationCode(_, let accessToken):
             return [
                 "Content-Type": "application/json",
                 "Accept": "application/json",
@@ -61,7 +64,7 @@ extension LifePoopLocalTarget: TargetType {
         default:
             return [
                 "Content-Type": "application/json",
-                "Accept": "application/json",
+                "Accept": "application/json"
             ]
         }
     }
@@ -77,7 +80,7 @@ extension LifePoopLocalTarget: TargetType {
 
     public var parameters: [String: Any]? {
         switch self {
-        case .signup, .login, .fetchStoolLog, .postStoolLog, .updateAccessToken, .fetchUserInfo:
+        default:
             return nil
         }
     }

--- a/Projects/Features/FeatureFriendList/FeatureFriendListCoordinator/Sources/DefaultFriendListCoordinator.swift
+++ b/Projects/Features/FeatureFriendList/FeatureFriendListCoordinator/Sources/DefaultFriendListCoordinator.swift
@@ -42,9 +42,16 @@ public final class DefaultFriendListCoordinator: FriendListCoordinator {
             case .showFirendList:
                 self?.showFriendListViewController()
             case .showFriendInvitation(let toastMessageStream, let friendListUpdateStream):
-                self?.showFriendInvitationView(toastMessageStream: toastMessageStream, friendListUpdateStream: friendListUpdateStream)
+                self?.showFriendInvitationView(
+                    toastMessageStream: toastMessageStream,
+                    friendListUpdateStream: friendListUpdateStream
+                )
             case .showInvitationCodePopup(let invitationType, let toastMessageStream, let friendListUpdateStream):
-                self?.showInvitationCodePopup(invitationType: invitationType, toastMessageStream: toastMessageStream)
+                self?.showInvitationCodePopup(
+                    invitationType: invitationType,
+                    toastMessageStream: toastMessageStream,
+                    friendListUpdateStream: friendListUpdateStream
+                )
             case .dismissInvitationCodePopup:
                 self?.dismissViewController()
             }
@@ -86,14 +93,19 @@ private extension DefaultFriendListCoordinator {
         self.bottomSheetController = bottomSheetController
     }
     
-    func showInvitationCodePopup(invitationType: InvitationType, toastMessageStream: PublishRelay<String>) {
+    func showInvitationCodePopup(
+        invitationType: InvitationType,
+        toastMessageStream: PublishRelay<String>,
+        friendListUpdateStream: PublishRelay<Void>
+    ) {
         closeBottomSheet()
         
         let invitationCodeViewController = InvitationCodeViewController()
         let invitationCodeViewModel = InvitationCodeViewModel(
             coordinator: self,
             invitationType: invitationType,
-            toastMessageStream: toastMessageStream
+            toastMessageStream: toastMessageStream,
+            friendListUpdateStream: friendListUpdateStream
         )
         invitationCodeViewController.bind(viewModel: invitationCodeViewModel)
         

--- a/Projects/Features/FeatureFriendList/FeatureFriendListCoordinator/Sources/DefaultFriendListCoordinator.swift
+++ b/Projects/Features/FeatureFriendList/FeatureFriendListCoordinator/Sources/DefaultFriendListCoordinator.swift
@@ -37,15 +37,17 @@ public final class DefaultFriendListCoordinator: FriendListCoordinator {
     }
     
     public func coordinate(by coordinateAction: FriendListCoordinateAction) {
-        switch coordinateAction {
-        case .shouldShowFirendList:
-            showFriendListViewController()
-        case .shouldShowFriendInvitation(let toastMessageStream):
-            showFriendInvitationView(with: toastMessageStream)
-        case .shouldShowInvitationCodePopup(let invitationType, let toastMessageStream):
-            showInvitationCodePopup(invitationType: invitationType, toastMessageStream: toastMessageStream)
-        case .shouldDismissInvitationCodePopup:
-            dismissViewController()
+        DispatchQueue.main.async { [weak self] in
+            switch coordinateAction {
+            case .shouldShowFirendList:
+                self?.showFriendListViewController()
+            case .shouldShowFriendInvitation(let toastMessageStream):
+                self?.showFriendInvitationView(with: toastMessageStream)
+            case .shouldShowInvitationCodePopup(let invitationType, let toastMessageStream):
+                self?.showInvitationCodePopup(invitationType: invitationType, toastMessageStream: toastMessageStream)
+            case .shouldDismissInvitationCodePopup:
+                self?.dismissViewController()
+            }
         }
     }
     

--- a/Projects/Features/FeatureFriendList/FeatureFriendListCoordinator/Sources/DefaultFriendListCoordinator.swift
+++ b/Projects/Features/FeatureFriendList/FeatureFriendListCoordinator/Sources/DefaultFriendListCoordinator.swift
@@ -33,19 +33,19 @@ public final class DefaultFriendListCoordinator: FriendListCoordinator {
     }
     
     public func start() {
-        coordinate(by: .shouldShowFirendList)
+        coordinate(by: .showFirendList)
     }
     
     public func coordinate(by coordinateAction: FriendListCoordinateAction) {
         DispatchQueue.main.async { [weak self] in
             switch coordinateAction {
-            case .shouldShowFirendList:
+            case .showFirendList:
                 self?.showFriendListViewController()
-            case .shouldShowFriendInvitation(let toastMessageStream):
-                self?.showFriendInvitationView(with: toastMessageStream)
-            case .shouldShowInvitationCodePopup(let invitationType, let toastMessageStream):
+            case .showFriendInvitation(let toastMessageStream, let friendListUpdateStream):
+                self?.showFriendInvitationView(toastMessageStream: toastMessageStream, friendListUpdateStream: friendListUpdateStream)
+            case .showInvitationCodePopup(let invitationType, let toastMessageStream, let friendListUpdateStream):
                 self?.showInvitationCodePopup(invitationType: invitationType, toastMessageStream: toastMessageStream)
-            case .shouldDismissInvitationCodePopup:
+            case .dismissInvitationCodePopup:
                 self?.dismissViewController()
             }
         }
@@ -65,10 +65,17 @@ private extension DefaultFriendListCoordinator {
         navigationController.pushViewController(viewController, animated: true)
     }
     
-    func showFriendInvitationView(with toastMessageStream: PublishRelay<String>) {
+    func showFriendInvitationView(
+        toastMessageStream: PublishRelay<String>,
+        friendListUpdateStream: PublishRelay<Void>
+    ) {
         
         let invitationViewController = FrinedInvitationViewController()
-        let invitationViewModel = FriendInvitationViewModel(coordinator: self, toastMessageStream: toastMessageStream)
+        let invitationViewModel = FriendInvitationViewModel(
+            coordinator: self,
+            toastMessageStream: toastMessageStream,
+            friendListUpdateStream: friendListUpdateStream
+        )
         invitationViewController.bind(viewModel: invitationViewModel)
         
         let parentViewController = navigationController

--- a/Projects/Features/FeatureFriendList/FeatureFriendListCoordinatorInterface/Sources/FriendListCoordinateAction.swift
+++ b/Projects/Features/FeatureFriendList/FeatureFriendListCoordinatorInterface/Sources/FriendListCoordinateAction.swift
@@ -14,8 +14,15 @@ import RxSwift
 import CoreEntity
 
 public enum FriendListCoordinateAction {
-    case shouldShowFirendList
-    case shouldShowFriendInvitation(toastMessageStream: PublishRelay<String>)
-    case shouldShowInvitationCodePopup(type: InvitationType, toastMessageStream: PublishRelay<String>)
-    case shouldDismissInvitationCodePopup
+    case showFirendList
+    case showFriendInvitation(
+        toastMessageStream: PublishRelay<String>,
+        friendListUpdateStream: PublishRelay<Void>
+    )
+    case showInvitationCodePopup(
+        type: InvitationType,
+        toastMessageStream: PublishRelay<String>,
+        friendListUpdateStream: PublishRelay<Void>
+    )
+    case dismissInvitationCodePopup
 }

--- a/Projects/Features/FeatureFriendList/FeatureFriendListPresentation/Sources/FriendInvitationViewController/FriendInvitationViewModel.swift
+++ b/Projects/Features/FeatureFriendList/FeatureFriendListPresentation/Sources/FriendInvitationViewController/FriendInvitationViewModel.swift
@@ -18,6 +18,8 @@ import FeatureFriendListUseCase
 import Logger
 import Utils
 
+// FIXME: 앱 배포 후, 리팩토링할 때 해당 뷰모델, 뷰컨트롤러를 FriendListViewController, ViewModel로 통합해야 함
+
 public final class FriendInvitationViewModel: ViewModelType {
     
     public struct Input {

--- a/Projects/Features/FeatureFriendList/FeatureFriendListPresentation/Sources/FriendInvitationViewController/FriendInvitationViewModel.swift
+++ b/Projects/Features/FeatureFriendList/FeatureFriendListPresentation/Sources/FriendInvitationViewController/FriendInvitationViewModel.swift
@@ -34,15 +34,28 @@ public final class FriendInvitationViewModel: ViewModelType {
     
     private var disposeBag = DisposeBag()
     
-    public init(coordinator: FriendListCoordinator?, toastMessageStream: PublishRelay<String>) {
-        bind(coordinator: coordinator, toastMessageStream: toastMessageStream)
+    public init(
+        coordinator: FriendListCoordinator?,
+        toastMessageStream: PublishRelay<String>,
+        friendListUpdateStream: PublishRelay<Void>
+    ) {
+        bind(coordinator: coordinator, toastMessageStream: toastMessageStream, friendListUpdateStream: friendListUpdateStream)
     }
     
-    private func bind(coordinator: FriendListCoordinator?, toastMessageStream: PublishRelay<String>) {
+    private func bind(
+        coordinator: FriendListCoordinator?,
+        toastMessageStream: PublishRelay<String>,
+        friendListUpdateStream: PublishRelay<Void>
+    ) {
         
         input.didSelectInvitationType
             .bind(onNext: { invitationType in
-                coordinator?.coordinate(by: .shouldShowInvitationCodePopup(type: invitationType, toastMessageStream: toastMessageStream))
+                coordinator?.coordinate(by: 
+                        .showInvitationCodePopup(
+                            type: invitationType,
+                            toastMessageStream: toastMessageStream,
+                            friendListUpdateStream: friendListUpdateStream
+                        ))
             })
             .disposed(by: disposeBag)
     }

--- a/Projects/Features/FeatureFriendList/FeatureFriendListPresentation/Sources/FriendListViewController/FriendListCollectionView/FriendListCollectionViewCell.swift
+++ b/Projects/Features/FeatureFriendList/FeatureFriendListPresentation/Sources/FriendListViewController/FriendListCollectionView/FriendListCollectionViewCell.swift
@@ -68,7 +68,7 @@ final class FriendListCollectionViewCell: UICollectionViewCell {
     }
     
     func configure(with friend: FriendEntity) {
-        nicknameLabel.text = friend.name
+        nicknameLabel.text = friend.nickname
         profileImageView.image = friend.profile.image
     }
 }

--- a/Projects/Features/FeatureFriendList/FeatureFriendListPresentation/Sources/FriendListViewController/FriendListViewController.swift
+++ b/Projects/Features/FeatureFriendList/FeatureFriendListPresentation/Sources/FriendListViewController/FriendListViewController.swift
@@ -76,7 +76,7 @@ public final class FriendListViewController: LifePoopViewController, ViewType {
             })
             .disposed(by: disposeBag)
         
-        output.shouldShowEmptyList
+        output.showEmptyList
             .withUnretained(self)
             .bind(onNext: { `self`, _ in
                 self.friendListCollectionView.isHidden = true
@@ -84,7 +84,7 @@ public final class FriendListViewController: LifePoopViewController, ViewType {
             })
             .disposed(by: disposeBag)
 
-        output.shouldShowFriendList
+        output.showFriendList
             .do(onNext: { [weak self] _ in
                 self?.emptyFriendListView.isHidden = true
                 self?.friendListCollectionView.isHidden = false
@@ -98,7 +98,7 @@ public final class FriendListViewController: LifePoopViewController, ViewType {
             }
             .disposed(by: disposeBag)
         
-        output.shouldShowToastMessge
+        output.showToastMessge
             .map { message in
                 let fullString = NSMutableAttributedString()
                 

--- a/Projects/Features/FeatureFriendList/FeatureFriendListPresentation/Sources/FriendListViewController/FriendListViewModel.swift
+++ b/Projects/Features/FeatureFriendList/FeatureFriendListPresentation/Sources/FriendListViewController/FriendListViewModel.swift
@@ -24,13 +24,14 @@ public final class FriendListViewModel: ViewModelType {
         let viewDidLoad = PublishRelay<Void>()
         let didSelectFirend = PublishRelay<FriendEntity>()
         let didTapInvitationButton = PublishRelay<Void>()
+        let didCompleteAddingFriend = PublishRelay<Void>()
     }
     
     public struct Output {
         let navigationTitle = Observable.of(LocalizableString.friendsList)
-        let shouldShowFriendList = BehaviorRelay<[FriendEntity]>(value: [])
-        let shouldShowEmptyList = PublishRelay<Void>()
-        let shouldShowToastMessge = PublishRelay<String>()
+        let showFriendList = BehaviorRelay<[FriendEntity]>(value: [])
+        let showEmptyList = PublishRelay<Void>()
+        let showToastMessge = PublishRelay<String>()
     }
     
     @Inject(FriendListDIContainer.shared) private var friendListUseCase: FriendListUseCase
@@ -52,20 +53,28 @@ public final class FriendListViewModel: ViewModelType {
             .withUnretained(self)
             .bind { `self`, _ in
                 coordinator?.coordinate(
-                    by: .shouldShowFriendInvitation(toastMessageStream: self.output.shouldShowToastMessge)
+                    by: .showFriendInvitation(
+                        toastMessageStream: self.output.showToastMessge,
+                        friendListUpdateStream: self.input.didCompleteAddingFriend
+                    )
                 )
             }
             .disposed(by: disposeBag)
         
-        input.viewDidLoad
+        let updateFriendList = Observable<Void>.merge(
+            input.viewDidLoad.asObservable(),
+            input.didCompleteAddingFriend.asObservable()
+        ).share()
+        
+        updateFriendList
             .withUnretained(self)
             .flatMap { `self`, _ in self.friendListUseCase.fetchFriendList() }
             .withUnretained(self)
             .bind(onNext: { `self`, friendList in
                 if friendList.isEmpty {
-                    self.output.shouldShowEmptyList.accept(())
+                    self.output.showEmptyList.accept(())
                 } else {
-                    self.output.shouldShowFriendList.accept(friendList)
+                    self.output.showFriendList.accept(friendList)
                 }
             })
             .disposed(by: disposeBag)

--- a/Projects/Features/FeatureFriendList/FeatureFriendListPresentation/Sources/FriendListViewController/FriendListViewModel.swift
+++ b/Projects/Features/FeatureFriendList/FeatureFriendListPresentation/Sources/FriendListViewController/FriendListViewModel.swift
@@ -69,6 +69,7 @@ public final class FriendListViewModel: ViewModelType {
         updateFriendList
             .withUnretained(self)
             .flatMap { `self`, _ in self.friendListUseCase.fetchFriendList() }
+            .observe(on: MainScheduler.asyncInstance)
             .withUnretained(self)
             .bind(onNext: { `self`, friendList in
                 if friendList.isEmpty {

--- a/Projects/Features/FeatureFriendList/FeatureFriendListPresentation/Sources/InvitationCodeViewController/InvitationCodeViewController.swift
+++ b/Projects/Features/FeatureFriendList/FeatureFriendListPresentation/Sources/InvitationCodeViewController/InvitationCodeViewController.swift
@@ -18,7 +18,10 @@ import Utils
 
 public final class InvitationCodeViewController: LifePoopViewController, ViewType {
     
-    private let textFieldAlertView = LifePoopTextFieldAlertView(type: .invitationCode, placeholder: "ex) vMXxaOXq")
+    private let textFieldAlertView = LifePoopTextFieldAlertView(
+        type: .invitationCode,
+        placeholder: "ex) vMXxaOXq"
+    )
     
     private var disposeBag = DisposeBag()
     public var viewModel: InvitationCodeViewModel?
@@ -107,8 +110,14 @@ private extension InvitationCodeViewController {
     }
     
     func showSharingPopup() {
-        let textToShare = "Invitation Code"
-        let activityViewController = UIActivityViewController(activityItems: [textToShare], applicationActivities: nil)
+        // TODO: 초대코드 존재하지 않을 경우 별도 표시해야 함
+        guard let invitationCode = viewModel?.invitationCode,
+              !invitationCode.isEmpty else { return }
+        
+        let activityViewController = UIActivityViewController(
+            activityItems: [invitationCode],
+            applicationActivities: nil
+        )
         
         // MARK: 우선적으로 필요없는 타입 제외
         activityViewController.excludedActivityTypes = [

--- a/Projects/Features/FeatureFriendList/FeatureFriendListPresentation/Sources/InvitationCodeViewController/InvitationCodeViewModel.swift
+++ b/Projects/Features/FeatureFriendList/FeatureFriendListPresentation/Sources/InvitationCodeViewController/InvitationCodeViewModel.swift
@@ -135,7 +135,7 @@ public final class InvitationCodeViewModel: ViewModelType {
             .withLatestFrom(input.didEnterInvitationCode)
             .withUnretained(self)
             .flatMapLatest { `self`, invitationCode in
-                self.friendListUseCase.sendInvitationCode(invitationCode)
+                self.friendListUseCase.requestAddingFriend(with: invitationCode)
             }
             .observe(on: MainScheduler.asyncInstance)
             .do(onNext: { [weak self] _ in

--- a/Projects/Features/FeatureFriendList/FeatureFriendListPresentation/Sources/InvitationCodeViewController/InvitationCodeViewModel.swift
+++ b/Projects/Features/FeatureFriendList/FeatureFriendListPresentation/Sources/InvitationCodeViewController/InvitationCodeViewModel.swift
@@ -20,22 +20,29 @@ import Utils
 
 public final class InvitationCodeViewModel: ViewModelType {
     
-    enum SharingResult: CustomStringConvertible {
+    enum ActionResult: CustomStringConvertible {
         case success(activity: Activity)
-        case failure(error: Error?)
+        case failure(activity: Activity, error: Error?)
         
         enum Activity {
             case sharing
             case copying
+            case addingFriend
         }
         
         var description: String {
             switch self {
             case .success(let activity):
-                return activity == .copying ?
-                LocalizableString.toastInvitationCodeCopySuccess :
-                LocalizableString.toastInvitationCodeSharingSuccess
+                switch activity {
+                case .sharing:
+                    return LocalizableString.toastInvitationCodeSharingSuccess
+                case .copying:
+                    return LocalizableString.toastInvitationCodeCopySuccess
+                case .addingFriend:
+                    return LocalizableString.toastAddingFriendSuccess
+                }
             case .failure:
+                
                 return LocalizableString.toastInvitationCodeSharingFail
             }
         }
@@ -46,21 +53,23 @@ public final class InvitationCodeViewModel: ViewModelType {
         let didEnterInvitationCode = PublishRelay<String>()
         let didTapConfirmButton = PublishRelay<Void>()
         let didTapCancelButton = PublishRelay<Void>()
-        let didCloseSharingPopup = PublishRelay<SharingResult?>()
+        let didCloseSharingPopup = PublishRelay<ActionResult?>()
         let didCloseInvitationCodePopup = PublishRelay<Void>()
     }
     
     public struct Output {
         let placeholder = BehaviorRelay<String>(value: "")
-        let shouldDismissAlertView = PublishRelay<Void>()
-        let shouldShowInvitationCodePopup = PublishRelay<Void>()
-        let shouldShowSharingActivityView = PublishRelay<Void>()
+        let dismissAlertView = PublishRelay<Void>()
+        let showInvitationCodePopup = PublishRelay<Void>()
+        let showSharingActivityView = PublishRelay<Void>()
         let enableConfirmButton = PublishRelay<Bool>()
         let hideWarningLabel = PublishRelay<Bool>()
     }
     
     public let input = Input()
     public let output = Output()
+    
+    @Inject(FriendListDIContainer.shared) private var friendListUseCase: FriendListUseCase
     
     private var disposeBag = DisposeBag()
     
@@ -76,9 +85,9 @@ public final class InvitationCodeViewModel: ViewModelType {
             .bind(onNext: { `self`, invitationType in
                 switch invitationType {
                 case .sharingInvitationCode:
-                    self.output.shouldShowSharingActivityView.accept(())
+                    self.output.showSharingActivityView.accept(())
                 case .enteringInvitationCode:
-                    self.output.shouldShowInvitationCodePopup.accept(())
+                    self.output.showInvitationCodePopup.accept(())
                 }
             })
             .disposed(by: disposeBag)
@@ -106,16 +115,26 @@ public final class InvitationCodeViewModel: ViewModelType {
             .disposed(by: disposeBag)
         
         input.didTapCancelButton
-            .bind(to: output.shouldDismissAlertView)
+            .bind(to: output.dismissAlertView)
             .disposed(by: disposeBag)
 
         input.didTapConfirmButton
             .withLatestFrom(input.didEnterInvitationCode)
-            .do(onNext: { invitationCode in
-                Logger.log(message: "초대코드 입력 확인 : \(invitationCode)", category: .default, type: .debug)
+            .withUnretained(self)
+            .flatMapLatest { `self`, invitationCode in
+                self.friendListUseCase.sendInvitationCode(invitationCode)
+            }
+            .observe(on: MainScheduler.asyncInstance)
+            .do(onNext: { [weak self] _ in
+                self?.output.dismissAlertView.accept(())
             })
-            .map { _ in Void() }
-            .bind(to: output.shouldDismissAlertView)
+            .map { isSuccess -> String in
+                let actionResult: ActionResult = isSuccess ? 
+                    .success(activity: .addingFriend) :
+                    .failure(activity: .addingFriend, error: nil)
+                return actionResult.description
+            }
+            .bind(to: toastMessageStream)
             .disposed(by: disposeBag)
 
         input.didCloseInvitationCodePopup

--- a/Projects/Features/FeatureFriendList/FeatureFriendListPresentation/Sources/InvitationCodeViewController/InvitationCodeViewModel.swift
+++ b/Projects/Features/FeatureFriendList/FeatureFriendListPresentation/Sources/InvitationCodeViewController/InvitationCodeViewModel.swift
@@ -95,7 +95,7 @@ public final class InvitationCodeViewModel: ViewModelType {
         input.didCloseSharingPopup
             .map { _ in Void() }
             .bind(onNext: { _ in
-                coordinator?.coordinate(by: .shouldDismissInvitationCodePopup)
+                coordinator?.coordinate(by: .dismissInvitationCodePopup)
             })
             .disposed(by: disposeBag)
         
@@ -139,7 +139,7 @@ public final class InvitationCodeViewModel: ViewModelType {
 
         input.didCloseInvitationCodePopup
             .bind(onNext: { _ in
-                coordinator?.coordinate(by: .shouldDismissInvitationCodePopup)
+                coordinator?.coordinate(by: .dismissInvitationCodePopup)
             })
             .disposed(by: disposeBag)
     }

--- a/Projects/Features/FeatureFriendList/FeatureFriendListPresentation/Sources/InvitationCodeViewController/InvitationCodeViewModel.swift
+++ b/Projects/Features/FeatureFriendList/FeatureFriendListPresentation/Sources/InvitationCodeViewController/InvitationCodeViewModel.swift
@@ -78,7 +78,8 @@ public final class InvitationCodeViewModel: ViewModelType {
     public init(
         coordinator: FriendListCoordinator?,
         invitationType: InvitationType,
-        toastMessageStream: PublishRelay<String>
+        toastMessageStream: PublishRelay<String>,
+        friendListUpdateStream: PublishRelay<Void>
     ) {
         
         input.viewDidAppear
@@ -147,7 +148,10 @@ public final class InvitationCodeViewModel: ViewModelType {
                     .failure(activity: .addingFriend, error: nil)
                 return actionResult.description
             }
-            .bind(to: toastMessageStream)
+            .bind(onNext: { toastMessage in
+                toastMessageStream.accept(toastMessage)
+                friendListUpdateStream.accept(())
+            })
             .disposed(by: disposeBag)
 
         input.didCloseInvitationCodePopup

--- a/Projects/Features/FeatureFriendList/FeatureFriendListPresentation/Sources/InvitationCodeViewController/InvitationCodeViewModel.swift
+++ b/Projects/Features/FeatureFriendList/FeatureFriendListPresentation/Sources/InvitationCodeViewController/InvitationCodeViewModel.swift
@@ -69,6 +69,8 @@ public final class InvitationCodeViewModel: ViewModelType {
     public let input = Input()
     public let output = Output()
     
+    private (set)var invitationCode: String = ""
+    
     @Inject(FriendListDIContainer.shared) private var friendListUseCase: FriendListUseCase
     
     private var disposeBag = DisposeBag()
@@ -78,6 +80,17 @@ public final class InvitationCodeViewModel: ViewModelType {
         invitationType: InvitationType,
         toastMessageStream: PublishRelay<String>
     ) {
+        
+        input.viewDidAppear
+            .withUnretained(self)
+            .flatMap { `self`, _ in
+                self.friendListUseCase.invitationCode
+            }
+            .withUnretained(self)
+            .bind(onNext: { `self`, invitationCode in
+                self.invitationCode = invitationCode
+            })
+            .disposed(by: disposeBag)
         
         input.viewDidAppear
             .map { invitationType }

--- a/Projects/Features/FeatureFriendList/FeatureFriendListRepository/Sources/DefaultFriendListRepository.swift
+++ b/Projects/Features/FeatureFriendList/FeatureFriendListRepository/Sources/DefaultFriendListRepository.swift
@@ -10,14 +10,42 @@ import Foundation
 
 import RxSwift
 
+import CoreDIContainer
 import CoreEntity
+import CoreNetworkService
 import FeatureFriendListUseCase
+import Logger
+import Utils
 
 public final class DefaultFriendListRepository: NSObject, FriendListRepository {
+
+    @Inject(CoreDIContainer.shared) private var urlSessionEndpointService: EndpointService
     
     public override init() { }
     
     public func fetchFriendList() -> Single<[FriendEntity]> {
         Single.just(FriendEntity.dummyData)
+    }
+    
+    public func sendInvitationCode(_ invitationCode: String, accessToken: String) -> Single<Result<Bool, Error>> {
+        urlSessionEndpointService
+            .fetchStatusCode(endpoint: LifePoopLocalTarget
+                .sendInvitationCode(
+                    code: invitationCode,
+                    accessToken: accessToken
+                ))
+            .map { statusCode -> Result<Bool, Error> in
+                switch statusCode {
+                case 201:
+                    return .success(true)
+                case 444:
+                    return .failure(NetworkError.invalidAccessToken)
+                default:
+                    return .failure(NetworkError.invalidStatusCode(code: statusCode))
+                }
+            }
+            .catch { error in
+                return .just(.failure(error))
+            }
     }
 }

--- a/Projects/Features/FeatureFriendList/FeatureFriendListRepository/Sources/DefaultFriendListRepository.swift
+++ b/Projects/Features/FeatureFriendList/FeatureFriendListRepository/Sources/DefaultFriendListRepository.swift
@@ -20,11 +20,17 @@ import Utils
 public final class DefaultFriendListRepository: NSObject, FriendListRepository {
 
     @Inject(CoreDIContainer.shared) private var urlSessionEndpointService: EndpointService
+    @Inject(CoreDIContainer.shared) private var friendEntityMapper: AnyDataMapper<FriendDTO, FriendEntity>
     
     public override init() { }
 
-    public func fetchFriendList() -> Single<[FriendEntity]> {
-        Single.just(FriendEntity.dummyData)
+    public func fetchFriendList(accessToken: String) -> Single<[FriendEntity]> {
+        urlSessionEndpointService
+            .fetchData(endpoint: LifePoopLocalTarget.fetchFriendList(
+                accessToken: accessToken
+            ))
+            .decodeMap([FriendDTO].self)
+            .transformMap(friendEntityMapper)
     }
     
     // MARK: 서버팀에서 정의한 상태코드에 대해서만 우선 예외 던짐 처리

--- a/Projects/Features/FeatureFriendList/FeatureFriendListUseCase/Sources/DefaultFriendListUseCase.swift
+++ b/Projects/Features/FeatureFriendList/FeatureFriendListUseCase/Sources/DefaultFriendListUseCase.swift
@@ -23,6 +23,12 @@ public final class DefaultFriendListUseCase: FriendListUseCase {
     @Inject(SharedDIContainer.shared) private var userInfoUseCase: UserInfoUseCase
     @Inject(FriendListDIContainer.shared) private var friendListRepository: FriendListRepository
     
+    public var invitationCode: Observable<String> {
+        userInfoUseCase.userInfo
+            .map { $0?.invitationCode ?? "" }
+            .asObservable()
+    }
+    
     public init() { }
     
     public func fetchFriendList() -> Observable<[FriendEntity]> {

--- a/Projects/Features/FeatureFriendList/FeatureFriendListUseCase/Sources/DefaultFriendListUseCase.swift
+++ b/Projects/Features/FeatureFriendList/FeatureFriendListUseCase/Sources/DefaultFriendListUseCase.swift
@@ -31,8 +31,18 @@ public final class DefaultFriendListUseCase: FriendListUseCase {
     public init() { }
     
     public func fetchFriendList() -> Observable<[FriendEntity]> {
-        friendListRepository
-            .fetchFriendList()
+        userInfoUseCase.userInfo
+            .compactMap { $0?.authInfo.accessToken }
+            .withUnretained(self)
+            .flatMapLatest { `self`, accessToken in
+                self.friendListRepository.fetchFriendList(accessToken: accessToken)
+                    .retry(when: { errorStream in
+                        // TODO: 추후 UseCase 수준에서 어떤 형태로든 '액세스 토큰'관련 에러에 대해서만 retry 하도록 처리해야 함
+                        errorStream.flatMap { _ in
+                            self.retryWhenAccessTokenIsInvalid()
+                        }
+                    })
+            }
             .asObservable()
     }
     
@@ -46,15 +56,18 @@ public final class DefaultFriendListUseCase: FriendListUseCase {
                     accessToken: accessToken
                 )
                 .retry(when: { errorStream in
-                    errorStream.flatMap { _ in
+                    errorStream.take(1).flatMap { _ in
                         self.retryWhenAccessTokenIsInvalid(invitationCode: invitationCode)
                     }
                 })
             }
             .asObservable()
     }
+}
+
+private extension DefaultFriendListUseCase {
     
-    private func retryWhenAccessTokenIsInvalid(invitationCode: String) -> Observable<Bool> {
+    func requestRefreshingAuthInfo() -> Observable<Bool> {
         let originalAuthInfo = userInfoUseCase.userInfo.compactMap { $0?.authInfo }
       
         Logger.log(
@@ -69,10 +82,23 @@ public final class DefaultFriendListUseCase: FriendListUseCase {
                 self.userInfoUseCase.refreshAuthInfo(with: authInfo)
             }
             .catchAndReturn(false)
+    }
+    
+    func retryWhenAccessTokenIsInvalid(invitationCode: String) -> Observable<Bool> {
+        requestRefreshingAuthInfo()
             .withUnretained(self)
             .flatMap { `self`, isSuccess -> Observable<Bool> in
                 guard isSuccess else { return .just(false) }
                 return self.requestAddingFriend(with: invitationCode)
+            }
+    }
+    
+    func retryWhenAccessTokenIsInvalid() -> Observable<[FriendEntity]> {
+        requestRefreshingAuthInfo()
+            .withUnretained(self)
+            .flatMap { `self`, isSuccess -> Observable<[FriendEntity]> in
+                guard isSuccess else { return .just([]) }
+                return self.fetchFriendList()
             }
     }
 }

--- a/Projects/Features/FeatureFriendList/FeatureFriendListUseCase/Sources/Interface/FriendListUseCase.swift
+++ b/Projects/Features/FeatureFriendList/FeatureFriendListUseCase/Sources/Interface/FriendListUseCase.swift
@@ -14,6 +14,7 @@ import CoreEntity
 
 public protocol FriendListUseCase {
     
+    var invitationCode: Observable<String> { get }    
     func fetchFriendList() -> Observable<[FriendEntity]>
     func sendInvitationCode(_ invitationCode: String) -> Observable<Bool>
 }

--- a/Projects/Features/FeatureFriendList/FeatureFriendListUseCase/Sources/Interface/FriendListUseCase.swift
+++ b/Projects/Features/FeatureFriendList/FeatureFriendListUseCase/Sources/Interface/FriendListUseCase.swift
@@ -15,4 +15,5 @@ import CoreEntity
 public protocol FriendListUseCase {
     
     func fetchFriendList() -> Observable<[FriendEntity]>
+    func sendInvitationCode(_ invitationCode: String) -> Observable<Bool>
 }

--- a/Projects/Features/FeatureFriendList/FeatureFriendListUseCase/Sources/Interface/FriendListUseCase.swift
+++ b/Projects/Features/FeatureFriendList/FeatureFriendListUseCase/Sources/Interface/FriendListUseCase.swift
@@ -14,7 +14,7 @@ import CoreEntity
 
 public protocol FriendListUseCase {
     
-    var invitationCode: Observable<String> { get }    
+    var invitationCode: Observable<String> { get }
     func fetchFriendList() -> Observable<[FriendEntity]>
-    func sendInvitationCode(_ invitationCode: String) -> Observable<Bool>
+    func requestAddingFriend(with invitationCode: String) -> Observable<Bool>
 }

--- a/Projects/Features/FeatureFriendList/FeatureFriendListUseCase/Sources/RepositoryInterface/FriendListRepository.swift
+++ b/Projects/Features/FeatureFriendList/FeatureFriendListUseCase/Sources/RepositoryInterface/FriendListRepository.swift
@@ -16,4 +16,5 @@ import Utils
 public protocol FriendListRepository: AnyObject {
     
     func fetchFriendList() -> Single<[FriendEntity]>
+    func sendInvitationCode(_ invitationCode: String, accessToken: String) -> Single<Result<Bool,Error>>
 }

--- a/Projects/Features/FeatureFriendList/FeatureFriendListUseCase/Sources/RepositoryInterface/FriendListRepository.swift
+++ b/Projects/Features/FeatureFriendList/FeatureFriendListUseCase/Sources/RepositoryInterface/FriendListRepository.swift
@@ -16,5 +16,8 @@ import Utils
 public protocol FriendListRepository: AnyObject {
     
     func fetchFriendList() -> Single<[FriendEntity]>
-    func sendInvitationCode(_ invitationCode: String, accessToken: String) -> Single<Result<Bool,Error>>
+    func requestAddingFriend(
+        with invitationCode: String,
+        accessToken: String
+    ) -> Single<Bool>
 }

--- a/Projects/Features/FeatureFriendList/FeatureFriendListUseCase/Sources/RepositoryInterface/FriendListRepository.swift
+++ b/Projects/Features/FeatureFriendList/FeatureFriendListUseCase/Sources/RepositoryInterface/FriendListRepository.swift
@@ -15,7 +15,7 @@ import Utils
 
 public protocol FriendListRepository: AnyObject {
     
-    func fetchFriendList() -> Single<[FriendEntity]>
+    func fetchFriendList(accessToken: String) -> Single<[FriendEntity]>
     func requestAddingFriend(
         with invitationCode: String,
         accessToken: String

--- a/Projects/Features/FeatureHome/FeatureHomePresentation/Sources/FriendListCollectionView/FriendListCollectionViewCell.swift
+++ b/Projects/Features/FeatureHome/FeatureHomePresentation/Sources/FriendListCollectionView/FriendListCollectionViewCell.swift
@@ -43,7 +43,7 @@ public final class FriendListCollectionViewCell: UICollectionViewCell {
 public extension FriendListCollectionViewCell {
     func configure(with friendEntity: FriendEntity) {
         profileImageView.image = friendEntity.feedImage
-        nameLabel.text = friendEntity.name
+        nameLabel.text = friendEntity.nickname
     }
 }
 

--- a/Projects/Features/FeatureHome/FeatureHomePresentation/Sources/FriendStoolStoryScene/FriendStoolStoryViewModel.swift
+++ b/Projects/Features/FeatureHome/FeatureHomePresentation/Sources/FriendStoolStoryScene/FriendStoolStoryViewModel.swift
@@ -83,7 +83,7 @@ public final class FriendStoolStoryViewModel: ViewModelType {
                     self.getTimeDifference(fromDateOf: stoolStoryLogs[currentIndex].stoolLog.date)
                 )
                 self.output.updateFriendStoolLogSummary.accept(
-                    LocalizableString.bowelMovementCountOfFriend(friend.name, totalCount)
+                    LocalizableString.bowelMovementCountOfFriend(friend.nickname, totalCount)
                 )
             })
             .disposed(by: disposeBag)

--- a/Projects/Features/FeatureHome/FeatureHomePresentation/Sources/StoolLogCollectionView/StoolLogHeaderView.swift
+++ b/Projects/Features/FeatureHome/FeatureHomePresentation/Sources/StoolLogCollectionView/StoolLogHeaderView.swift
@@ -117,7 +117,7 @@ final class StoolLogHeaderView: UICollectionReusableView, ViewType {
         
         output.updateUserProfileCharacter
             .asSignal()
-            .map { ($0.feedImage, $0.name) }
+            .map { ($0.feedImage, $0.nickname) }
             .emit(onNext: inviteFriendView.setMyProfileCharactor(image:name:))
             .disposed(by: disposeBag)
         

--- a/Projects/Utils/Resources/Localizable.strings
+++ b/Projects/Utils/Resources/Localizable.strings
@@ -171,6 +171,8 @@
 "toastChangeAutoLoginSuccess" = "자동 로그인 설정이 성공적으로 변경되었습니다.";
 "toastChangeAutoLoginFail" = "자동 로그인 설정을 변경하는 데 실패했습니다.";
 
+"toastAddingFriendSuccess" = "친구 추가 완료";
+"toastAddingFriendFail" = "친구 추가 실패";
 "toastInvitationCodeCopySuccess" = "초대 코드 복사 완료";
 "toastInvitationCodeSharingSuccess" = "초대 코드 공유 완료";
 "toastInvitationCodeSharingFail" = "초대 코드 공유 실패";


### PR DESCRIPTION
### 🔖 관련 이슈
- #85 

<br> 

### ⚒️ 작업 내역

- [x] 친구 목록 조회 api 연동
- [x] 친구 목록 조회 api 연동
- [x] 친구 목록 조회 api 연동

<br>

### 💻 리뷰어 가이드
회원 가입 후 아래 동작들 확인하시면 됩니다.

- 친구목록 화면 진입 > 친구목록이 없을 때 빈 화면 캐릭터 노출
- 친구목록 화면 진입 > 친구목록이 있을 때 친구 목록 컬렉션뷰 노출
- 친구 목록 화면 진입 > 팝업 노출 후 초대코드 입력 선택 > 초대코드 입력 > 요청 결과 토스트 메시지 노출 및 컬렉션 뷰 업데이트
- 친구 목록 화면 진입 > 팝업 노출 후 초대코드 입력 선택 > 초대코드 공유 > 아무 동작이나 했을 때 클립보드에 정상적으로 로그인된 사용자의 초대코드가 노출

<br>

### 📝 부가 설명
- 슬랙으로 한 번 얘기했던, 인증토큰 만료 후 재처리하는 과정을 시간 편하실 때 한 번 같이 논의해보아요~😄