### PR TITLE
홈 화면의 응원중인 친구 문구와 프로필 캐릭터 연동 구현

### DIFF
--- a/Projects/Core/CoreEntity/Sources/CheeringInfoEntity.swift
+++ b/Projects/Core/CoreEntity/Sources/CheeringInfoEntity.swift
@@ -18,3 +18,21 @@ public struct CheeringInfoEntity {
     public let count: Int
     public let friends: [CheeringFriendInfoEntity]
 }
+
+public extension CheeringInfoEntity {
+    var extraCount: Int {
+        return count - 1
+    }
+    
+    var friendName: String? {
+        return friends.first?.nickname
+    }
+    
+    var firstFriendProfileCharacter: ProfileCharacter? {
+        return friends.first?.profileCharacter
+    }
+    
+    var secondFriendProfileCharacter: ProfileCharacter? {
+        return friends.indices.contains(1) ? friends[1].profileCharacter : nil
+    }
+}

--- a/Projects/DesignSystem/Resources/Localizable.strings
+++ b/Projects/DesignSystem/Resources/Localizable.strings
@@ -22,6 +22,9 @@
 "paste" = "붙여넣기";
 
 /* CheeringButtonView */
+"friendIsCheeringYou" = "%@님이 응원하고 있어요!";
+"multipleFriendsAreCheeringYou" = "%@님 외 %d명이 응원하고 있어요!";
+"noCheeringYet" = "아직 받은 응원이 없어요";
 "goToFriendList" = "친구 목록으로 이동하기";
 
 /* SuggestionButton */

--- a/Projects/DesignSystem/Sources/Component/UIView/CheeringButtonView.swift
+++ b/Projects/DesignSystem/Sources/Component/UIView/CheeringButtonView.swift
@@ -1,6 +1,6 @@
 //
 //  CheeringButtonView.swift
-//  FeatureHomePresentation
+//  DesignSystem
 //
 //  Created by 김상혁 on 2023/05/03.
 //  Copyright © 2023 LifePoop. All rights reserved.
@@ -12,16 +12,19 @@ import SnapKit
 
 public final class CheeringButtonView: ShadowView {
     
-    private let cheeringFriendImageView: UIImageView = {
+    private let emptyCheeringFriendImageView: UIImageView = {
         let imageView = UIImageView()
-        imageView.image = ImageAsset.cheeringFriends.original
+        imageView.image = ImageAsset.emptyThreeDots.original
         imageView.contentMode = .scaleAspectFit
         return imageView
     }()
     
+    private let cheeringFriendProfileCharacterView = CheeringFriendProfileCharacterView()
+    
     public let titleLabel: UILabel = {
         let label = UILabel()
         label.adjustsFontSizeToFitWidth = true
+        label.text = DesignSystemStrings.noCheeringYet
         label.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
         return label
     }()
@@ -65,15 +68,6 @@ public final class CheeringButtonView: ShadowView {
     }
 }
 
-// MARK: - Public Methods
-
-public extension CheeringButtonView {
-    func toggleCheeringFriendImage(by isCheeringFriendEmpty: Bool) {
-        let image = isCheeringFriendEmpty ? ImageAsset.cheeringFriends.original : ImageAsset.emptyThreeDots.original
-        cheeringFriendImageView.image = image
-    }
-}
-
 // MARK: - UI Configuration
 
 private extension CheeringButtonView {
@@ -88,12 +82,18 @@ private extension CheeringButtonView {
 
 private extension CheeringButtonView {
     func layoutUI() {
-        addSubview(cheeringFriendImageView)
+        addSubview(emptyCheeringFriendImageView)
+        addSubview(cheeringFriendProfileCharacterView)
         addSubview(titleStackView)
         addSubview(expandRightImageView)
         addSubview(containerButton)
         
-        cheeringFriendImageView.snp.makeConstraints { make in
+        emptyCheeringFriendImageView.snp.makeConstraints { make in
+            make.leading.equalToSuperview().offset(20)
+            make.top.equalTo(titleStackView).offset(10.5)
+        }
+        
+        cheeringFriendProfileCharacterView.snp.makeConstraints { make in
             make.leading.equalToSuperview().offset(20)
             make.top.equalTo(titleStackView)
         }
@@ -101,7 +101,7 @@ private extension CheeringButtonView {
         titleStackView.snp.makeConstraints { make in
             make.top.equalToSuperview().offset(17.5)
             make.bottom.equalToSuperview().inset(20.5)
-            make.leading.equalTo(cheeringFriendImageView.snp.trailing).offset(12)
+            make.leading.equalTo(emptyCheeringFriendImageView.snp.trailing).offset(12)
             make.trailing.equalToSuperview().inset(20)
         }
         
@@ -112,6 +112,47 @@ private extension CheeringButtonView {
         
         containerButton.snp.makeConstraints { make in
             make.edges.equalToSuperview()
+        }
+    }
+}
+
+// MARK: - Public Methods
+
+public extension CheeringButtonView {
+    func updateCheeringFriend(name: String, extraCount: Int) {
+        if extraCount >= 1 {
+            titleLabel.text = DesignSystemStrings.multipleFriendsAreCheeringYou(name, extraCount)
+        } else {
+            titleLabel.text = DesignSystemStrings.friendIsCheeringYou(name)
+        }
+    }
+    
+    func showCheeringFriendImage(firstImage: UIImage?, secondImage: UIImage? = nil) {
+        emptyCheeringFriendImageView.isHidden = true
+        cheeringFriendProfileCharacterView.isHidden = false
+        cheeringFriendProfileCharacterView.setCheeringFriendProfileCharacter(
+            firstImage: firstImage,
+            secondImage: secondImage
+        )
+        
+        titleStackView.snp.remakeConstraints { make in
+            make.top.equalToSuperview().offset(17.5)
+            make.bottom.equalToSuperview().inset(20.5)
+            make.leading.equalTo(cheeringFriendProfileCharacterView.snp.trailing).offset(12)
+            make.trailing.equalToSuperview().inset(20)
+        }
+    }
+    
+    func showEmptyCheeringFriendImage() {
+        emptyCheeringFriendImageView.isHidden = false
+        cheeringFriendProfileCharacterView.isHidden = true
+        titleLabel.text = DesignSystemStrings.noCheeringYet
+        
+        titleStackView.snp.remakeConstraints { make in
+            make.top.equalToSuperview().offset(17.5)
+            make.bottom.equalToSuperview().inset(20.5)
+            make.leading.equalTo(emptyCheeringFriendImageView.snp.trailing).offset(12)
+            make.trailing.equalToSuperview().inset(20)
         }
     }
 }

--- a/Projects/DesignSystem/Sources/Component/UIView/CheeringFriendProfileCharacterView.swift
+++ b/Projects/DesignSystem/Sources/Component/UIView/CheeringFriendProfileCharacterView.swift
@@ -1,0 +1,82 @@
+//
+//  CheeringFriendProfileCharacterView.swift
+//  DesignSystem
+//
+//  Created by 김상혁 on 2023/10/31.
+//  Copyright © 2023 Lifepoo. All rights reserved.
+//
+
+import UIKit
+
+import SnapKit
+
+
+public final class CheeringFriendProfileCharacterView: UIView {
+    
+    private let insetBetweenImages: CGFloat = 6.0
+    
+    private let firstCheeringFriendImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFit
+        return imageView
+    }()
+    
+    private let secondCheeringFriendImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFit
+        return imageView
+    }()
+    
+    public override var intrinsicContentSize: CGSize {
+        let firstImageHeight = firstCheeringFriendImageView.image?.size.height ?? .zero
+        let secondImageHeight = secondCheeringFriendImageView.image?.size.height ?? .zero
+        
+        let firstImageWidth = firstCheeringFriendImageView.image?.size.width ?? .zero
+        let secondImageWidth = secondCheeringFriendImageView.image?.size.width ?? .zero
+        let imageInset: CGFloat = (secondImageWidth > .zero) ? insetBetweenImages : .zero
+        
+        let intrinsicHeight = max(firstImageWidth, secondImageWidth)
+        let intrinsicWidth = firstImageWidth + secondImageWidth - imageInset
+        
+        return CGSize(width: intrinsicWidth, height: intrinsicHeight)
+    }
+    
+    public init() {
+        super.init(frame: .zero)
+        layoutUI()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - UI Layout
+
+private extension CheeringFriendProfileCharacterView {
+    func layoutUI() {
+        addSubview(firstCheeringFriendImageView)
+        addSubview(secondCheeringFriendImageView)
+        
+        firstCheeringFriendImageView.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.leading.equalToSuperview()
+        }
+        
+        secondCheeringFriendImageView.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.leading.equalTo(firstCheeringFriendImageView.snp.trailing).inset(insetBetweenImages)
+        }
+    }
+}
+
+// MARK: - Public Methods
+
+public extension CheeringFriendProfileCharacterView {
+    func setCheeringFriendProfileCharacter(firstImage: UIImage?, secondImage: UIImage? = nil) {
+        firstCheeringFriendImageView.image = firstImage
+        secondCheeringFriendImageView.image = secondImage
+        invalidateIntrinsicContentSize()
+    }
+}

--- a/Projects/EntityUIMapper/Sources/ProfileCharacter+image.swift
+++ b/Projects/EntityUIMapper/Sources/ProfileCharacter+image.swift
@@ -116,4 +116,39 @@ public extension ProfileCharacter {
             return ImageAsset.profileSoftYellowLarge.original
         }
     }
+    
+    var cheeringImage: UIImage {
+        switch (shape, color) {
+        case (.good, .black):
+            return ImageAsset.profileCheeringGoodBlack.original
+        case (.good, .pink):
+            return ImageAsset.profileCheeringGoodRed.original
+        case (.good, .brown):
+            return ImageAsset.profileCheeringGoodBrown.original
+        case (.good, .green):
+            return ImageAsset.profileCheeringGoodGreen.original
+        case (.good, .yellow):
+            return ImageAsset.profileCheeringGoodYellow.original
+        case (.hard, .black):
+            return ImageAsset.profileCheeringHardBlack.original
+        case (.hard, .brown):
+            return ImageAsset.profileCheeringHardBrown.original
+        case (.hard, .green):
+            return ImageAsset.profileCheeringHardGreen.original
+        case (.hard, .pink):
+            return ImageAsset.profileCheeringHardRed.original
+        case (.hard, .yellow):
+            return ImageAsset.profileCheeringHardYellow.original
+        case (.soft, .black):
+            return ImageAsset.profileCheeringSoftBlack.original
+        case (.soft, .brown):
+            return ImageAsset.profileCheeringSoftBrown.original
+        case (.soft, .green):
+            return ImageAsset.profileCheeringSoftGreen.original
+        case (.soft, .pink):
+            return ImageAsset.profileCheeringSoftRed.original
+        case (.soft, .yellow):
+            return ImageAsset.profileCheeringSoftYellow.original
+        }
+    }
 }

--- a/Projects/Features/FeatureHome/FeatureHomePresentation/Sources/StoolLogCollectionView/StoolLogHeaderView.swift
+++ b/Projects/Features/FeatureHome/FeatureHomePresentation/Sources/StoolLogCollectionView/StoolLogHeaderView.swift
@@ -15,6 +15,7 @@ import SnapKit
 import CoreEntity
 import DesignSystem
 import DesignSystemReactive
+import EntityUIMapper
 import Utils
 
 final class StoolLogHeaderView: UICollectionReusableView, ViewType {
@@ -136,9 +137,15 @@ final class StoolLogHeaderView: UICollectionReusableView, ViewType {
             .emit(to: todayStoolLogLabel.rx.text)
             .disposed(by: disposeBag)
         
-        output.setFriendsCheeringDescription
+        output.updateCheeringProfileCharacters
             .asSignal()
-            .emit(to: cheeringButtonView.rx.titleText)
+            .map { ($0.0?.cheeringImage, $0.1?.cheeringImage) }
+            .emit(onNext: cheeringButtonView.showCheeringFriendImage)
+            .disposed(by: disposeBag)
+        
+        output.updateCheeringFriendNameAndCount
+            .asSignal()
+            .emit(onNext: cheeringButtonView.updateCheeringFriend)
             .disposed(by: disposeBag)
     }
 }

--- a/Projects/Features/FeatureHome/FeatureHomePresentation/Sources/StoolLogCollectionView/StoolLogHeaderView.swift
+++ b/Projects/Features/FeatureHome/FeatureHomePresentation/Sources/StoolLogCollectionView/StoolLogHeaderView.swift
@@ -147,6 +147,11 @@ final class StoolLogHeaderView: UICollectionReusableView, ViewType {
             .asSignal()
             .emit(onNext: cheeringButtonView.updateCheeringFriend)
             .disposed(by: disposeBag)
+        
+        output.showEmptyCheeringInfo
+            .asSignal()
+            .emit(onNext: cheeringButtonView.showEmptyCheeringFriendImage)
+            .disposed(by: disposeBag)
     }
 }
 

--- a/Projects/Features/FeatureHome/FeatureHomePresentation/Sources/StoolLogCollectionView/StoolLogHeaderViewModel.swift
+++ b/Projects/Features/FeatureHome/FeatureHomePresentation/Sources/StoolLogCollectionView/StoolLogHeaderViewModel.swift
@@ -82,6 +82,30 @@ public final class StoolLogHeaderViewModel: ViewModelType {
             .bind(to: output.isFriendEmpty)
             .disposed(by: disposeBag)
         
+        viewDidLoadOrRefresh
+            .withLatestFrom(state.cheeringInfo)
+            .compactMap { $0 }
+            .filter { $0.count > .zero }
+            .map { ($0.firstFriendProfileCharacter, $0.secondFriendProfileCharacter) }
+            .bind(to: output.updateCheeringProfileCharacters)
+            .disposed(by: disposeBag)
+        
+        viewDidLoadOrRefresh
+            .withLatestFrom(state.cheeringInfo)
+            .compactMap { $0 }
+            .filter { $0.count > .zero }
+            .map { (name: $0.friendName ?? "", count: $0.extraCount) }
+            .bind(to: output.updateCheeringFriendNameAndCount)
+            .disposed(by: disposeBag)
+        
+        viewDidLoadOrRefresh
+            .withLatestFrom(state.cheeringInfo)
+            .compactMap { $0 }
+            .filter { $0.count == .zero }
+            .map { _ in }
+            .bind(to: output.showEmptyCheeringInfo)
+            .disposed(by: disposeBag)
+        
         let friendListCellIndex = input.friendListCellDidTap
             .map { $0.item }
             .share()
@@ -107,37 +131,6 @@ public final class StoolLogHeaderViewModel: ViewModelType {
         )
         .bind { coordinator?.coordinate(by: .cheeringButtonDidTap) }
         .disposed(by: disposeBag)
-        
-        state.cheeringInfo
-            .compactMap { $0 }
-            .filter { $0.count > .zero }
-            .map { ($0.firstFriendProfileCharacter, $0.secondFriendProfileCharacter) }
-            .bind(to: output.updateCheeringProfileCharacters)
-            .disposed(by: disposeBag)
-        
-        state.cheeringInfo
-            .compactMap { $0 }
-            .filter { $0.count > .zero }
-            .map { (name: $0.friendName ?? "", count: $0.extraCount) }
-            .bind(to: output.updateCheeringFriendNameAndCount)
-            .disposed(by: disposeBag)
-        
-        state.cheeringInfo
-            .compactMap { $0 }
-            .filter { $0.count == .zero }
-            .map { _ in }
-            .bind(to: output.showEmptyCheeringInfo)
-            .disposed(by: disposeBag)
-        
-        state.friends
-            .compactMap { $0 }
-            .bind(to: output.updateFriends)
-            .disposed(by: disposeBag)
-        
-        state.friends
-            .map { $0.isEmpty }
-            .bind(to: output.isFriendEmpty)
-            .disposed(by: disposeBag)
     }
     
     deinit {

--- a/Projects/Features/FeatureHome/FeatureHomeUseCase/Sources/DefaultHomeUseCase.swift
+++ b/Projects/Features/FeatureHome/FeatureHomeUseCase/Sources/DefaultHomeUseCase.swift
@@ -20,10 +20,22 @@ import Utils
 public final class DefaultHomeUseCase: HomeUseCase {
     
     @Inject(SharedDIContainer.shared) private var userInfoUseCase: UserInfoUseCase
+    @Inject(SharedDIContainer.shared) private var cheeringInfoUseCase: CheeringInfoUseCase
     @Inject(SharedDIContainer.shared) private var stoolLogUseCase: StoolLogUseCase
     @Inject(SharedDIContainer.shared) private var friendListRepository: FriendListRepository
     
     public init() { }
+    
+    public func fetchCheeringInfo(at date: String) -> Observable<CheeringInfoEntity> {
+        return userInfoUseCase.userInfo
+            .compactMap { $0?.userId }
+            .debug()
+            .withUnretained(self)
+            .flatMapLatest { `self`, userId in
+                self.cheeringInfoUseCase.fetchCheeringInfo(userId: userId, date: date)
+            }
+            .asObservable()
+    }
     
     public func fetchFriendList() -> Observable<[FriendEntity]> {
         return userInfoUseCase.userInfo

--- a/Projects/Features/FeatureHome/FeatureHomeUseCase/Sources/Interface/HomeUseCase.swift
+++ b/Projects/Features/FeatureHome/FeatureHomeUseCase/Sources/Interface/HomeUseCase.swift
@@ -11,6 +11,7 @@ import RxSwift
 import CoreEntity
 
 public protocol HomeUseCase {
+    func fetchCheeringInfo(at date: String) -> Observable<CheeringInfoEntity>
     func fetchFriendList() -> Observable<[FriendEntity]>
     func fetchStoolLogs() -> Observable<[StoolLogEntity]>
     

--- a/Projects/Utils/Resources/Localizable.strings
+++ b/Projects/Utils/Resources/Localizable.strings
@@ -153,6 +153,9 @@
 "toastFetchStoolLogSuccess" = "변 기록을 성공적으로 불러왔습니다.";
 "toastFetchStoolLogFail" = "변 기록을 불러오는 데 실패했습니다.";
 
+"toastFetchCheeringInfoSuccess" = "응원 정보를 성공적으로 불러왔습니다.";
+"toastFetchCheeringInfoFail" = "응원 정보를 불러오는 데 실패했습니다.";
+
 "toastPostStoolLogSuccess" = "새로운 변 기록이 등록했습니다.";
 "toastPostStoolLogFail" = "변 기록을 등록하는 데 실패했습니다.";
 

--- a/Projects/Utils/Sources/Enum/ToastMessage.swift
+++ b/Projects/Utils/Sources/Enum/ToastMessage.swift
@@ -11,6 +11,7 @@ import Foundation
 public enum ToastMessage {
     case auth(Auth)
     case friendList(FriendList)
+    case cheeringInfo(CheeringInfo)
     case stoolLog(StoolLog)
     case setting(Setting)
     case invitation(Invitation)
@@ -30,6 +31,13 @@ public enum ToastMessage {
                 return LocalizableString.toastFetchFriendListSuccess
             case .fetchFriendListFail:
                 return LocalizableString.toastFetchFriendListFail
+            }
+        case .cheeringInfo(let cheeringInfo):
+            switch cheeringInfo {
+            case .fetchCheeringInfoSuccess:
+                return LocalizableString.toastFetchCheeringInfoSuccess
+            case .fetchCheeringInfoFail:
+                return LocalizableString.toastFetchCheeringInfoFail
             }
         case .stoolLog(let stoolLog):
             switch stoolLog {
@@ -89,6 +97,13 @@ public extension ToastMessage {
     enum FriendList {
         case fetchFriendListSuccess
         case fetchFriendListFail
+    }
+}
+
+public extension ToastMessage {
+    enum CheeringInfo {
+        case fetchCheeringInfoSuccess
+        case fetchCheeringInfoFail
     }
 }
 


### PR DESCRIPTION
### 🔖 관련 이슈
- #119 

<br> 

### ⚒️ 작업 내역

- [x] 응원 중인 친구의 이름을 표기 (1명일 경우, 2명 이상일 경우에 대해 각각)
- [x] 응원 중인 친구의 프로필 캐릭터를 표기 (1명일 경우, 2명 이상일 경우에 대해 각각)

<br>

### 📑 첨부 자료

|응원 중인 친구가 없음|응원 중인 친구가 1명|응원 중인 친구가 2명 이상|
|-----|-----|-----|
|<img src="https://github.com/LifePoop/LifePoop_iOS/assets/57667738/57f13672-5e39-435f-8091-dc2d1bd305a1" width="100%">|<img src="https://github.com/LifePoop/LifePoop_iOS/assets/57667738/093d6bd1-5347-4ae4-a976-8b6561276c00" width="100%">|<img src="https://github.com/LifePoop/LifePoop_iOS/assets/57667738/900a352a-403d-4f46-b3e8-a9e3a9267a2c" width="100%">|

