### PR TITLE
CheeringFriendInfo DTO와 Entity에 대한 네이밍 수정

### DIFF
--- a/Projects/Core/CoreEntity/Sources/CheeringInfoEntity.swift
+++ b/Projects/Core/CoreEntity/Sources/CheeringInfoEntity.swift
@@ -10,13 +10,13 @@ import Foundation
 
 public struct CheeringInfoEntity {
     
-    public init(count: Int, friends: [CheeringFriendInfoEntity]) {
+    public init(count: Int, friends: [UserProfileEntity]) {
         self.count = count
         self.friends = friends
     }
     
     public let count: Int
-    public let friends: [CheeringFriendInfoEntity]
+    public let friends: [UserProfileEntity]
 }
 
 public extension CheeringInfoEntity {

--- a/Projects/Core/CoreEntity/Sources/StoryFeedEntity.swift
+++ b/Projects/Core/CoreEntity/Sources/StoryFeedEntity.swift
@@ -11,10 +11,10 @@ import Foundation
 public struct StoryFeedEntity {
     public let hashId: UUID = UUID()
     
-    public let user: CheeringFriendInfoEntity
+    public let user: UserProfileEntity
     public let stories: [StoryEntity]
     
-    public init(user: CheeringFriendInfoEntity, stories: [StoryEntity]) {
+    public init(user: UserProfileEntity, stories: [StoryEntity]) {
         self.user = user
         self.stories = stories
     }

--- a/Projects/Core/CoreEntity/Sources/UserProfileEntity.swift
+++ b/Projects/Core/CoreEntity/Sources/UserProfileEntity.swift
@@ -1,5 +1,5 @@
 //
-//  CheeringFriendInfoEntity.swift
+//  UserProfileEntity.swift
 //  CoreEntity
 //
 //  Created by 김상혁 on 2023/10/29.
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct CheeringFriendInfoEntity {
+public struct UserProfileEntity {
     
     public init(nickname: String, profileCharacter: ProfileCharacter) {
         self.nickname = nickname

--- a/Projects/Core/CoreNetworkService/Sources/DTO/CheeringInfoDTO.swift
+++ b/Projects/Core/CoreNetworkService/Sources/DTO/CheeringInfoDTO.swift
@@ -10,5 +10,5 @@ import Foundation
 
 public struct CheeringInfoDTO: Decodable {
     let count: Int
-    let thumbs: [CheeringFriendInfoDTO]
+    let thumbs: [UserProfileDTO]
 }

--- a/Projects/Core/CoreNetworkService/Sources/DTO/StoryFeedDTO.swift
+++ b/Projects/Core/CoreNetworkService/Sources/DTO/StoryFeedDTO.swift
@@ -10,10 +10,10 @@ import Foundation
 
 public struct StoryFeedDTO: Decodable {
     
-    public let user: CheeringFriendInfoDTO
+    public let user: UserProfileDTO
     public let stories: [StoryDTO]
     
-    public init(user: CheeringFriendInfoDTO, stories: [StoryDTO]) {
+    public init(user: UserProfileDTO, stories: [StoryDTO]) {
         self.user = user
         self.stories = stories
     }

--- a/Projects/Core/CoreNetworkService/Sources/DTO/UserProfileDTO.swift
+++ b/Projects/Core/CoreNetworkService/Sources/DTO/UserProfileDTO.swift
@@ -1,5 +1,5 @@
 //
-//  CheeringFriendInfoDTO.swift
+//  UserProfileDTO.swift
 //  CoreNetworkService
 //
 //  Created by 김상혁 on 2023/10/29.
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct CheeringFriendInfoDTO: Decodable {
+public struct UserProfileDTO: Codable {
     let nickname: String
     let characterColor, characterShape: Int
 }

--- a/Projects/Core/CoreNetworkService/Sources/DataMapper/CheeringInfoEntityMapper.swift
+++ b/Projects/Core/CoreNetworkService/Sources/DataMapper/CheeringInfoEntityMapper.swift
@@ -23,7 +23,7 @@ public struct CheeringInfoEntityMapper: DataMapper {
                     throw NetworkError.dataMappingError
                 }
                 
-                return CheeringFriendInfoEntity(
+                return UserProfileEntity(
                     nickname: $0.nickname,
                     profileCharacter: ProfileCharacter(
                         color: color,

--- a/Projects/Core/CoreNetworkService/Sources/DataMapper/StoryFeedEntityMapper.swift
+++ b/Projects/Core/CoreNetworkService/Sources/DataMapper/StoryFeedEntityMapper.swift
@@ -21,7 +21,7 @@ public struct StoryFeedEntityMapper: DataMapper {
         }
         let nickname = dto.user.nickname
         return StoryFeedEntity(
-            user: CheeringFriendInfoEntity(nickname: nickname, profileCharacter: ProfileCharacter(
+            user: UserProfileEntity(nickname: nickname, profileCharacter: ProfileCharacter(
                 color: color,
                 shape: shape
             )),


### PR DESCRIPTION

### 🔖 관련 이슈
- #132

<br> 

### ⚒️ 작업 내역

- [x] CheeringFriendInfo -> UserProfile 네이밍 변경

<br>

### 📝 부가 설명

```json
{
    "nickname": "string",       
    "characterColor": 0,
    "characterShape": 0
}
```
위 타입을 저장하는 구조체의 이름을 더 범용적으로 사용할 수 있도록 네이밍을 수정했습니다.
CheeringFriendInfoDTO -> UserProfileDTO
CheeringFriendInfoEntity -> UserProfileEntity