### PR TITLE
앱 버전 업데이트 후 소셜 로그인 에러, 카카오 로그인 후 탈퇴 시 애플 팝업 창 뜨는 이슈 해결

### DIFF
--- a/Projects/Features/FeatureSetting/FeatureSettingPresentation/Sources/SettingViewModel.swift
+++ b/Projects/Features/FeatureSetting/FeatureSettingPresentation/Sources/SettingViewModel.swift
@@ -220,9 +220,11 @@ public final class SettingViewModel: ViewModelType {
         .disposed(by: disposeBag)
         
         input.withdrawConfirmButtonDidTap
+            .withLatestFrom(state.userLoginType)
+            .compactMap { $0 }
             .withUnretained(self)
-            .flatMap { `self`, _ in
-                self.userInfoUseCase.requestAccountWithdrawl(for: .apple)
+            .flatMap { `self`, loginType in
+                self.userInfoUseCase.requestAccountWithdrawl(for: loginType)
             }
             .withUnretained(self)
             .bind { `self`, isSuccess in

--- a/Projects/Shared/SharedRepository/Sources/DefaultKeyChainRepository.swift
+++ b/Projects/Shared/SharedRepository/Sources/DefaultKeyChainRepository.swift
@@ -122,12 +122,9 @@ private extension DefaultKeyChainRepository {
         let encodedData = try JSONEncoder().encode(object)
         
         let keychainQuery = keychainQuery(for: .save, key: key, value: encodedData)
-        let alreadyExistingItem: T? = try getObjectFromKeyChain(
-            asTypeOf: T.self,
-            forKey: key,
-            handleExceptionWhenValueNotFound: false
-        )
-        let isObjectAlreadyExists = alreadyExistingItem != nil
+        let alreadyExistingData: Data? = try getBinaryDataFromKeyChain(forKey: key)
+        let isObjectAlreadyExists = alreadyExistingData != nil
+
         if isObjectAlreadyExists {
             try removeExistingObjectFromKeyChain(forKey: key)
         }


### PR DESCRIPTION
### 🔖 관련 이슈
- #130 

<br> 

### ⚒️ 작업 내역

- [x] 앱 버전 업데이트 후 소셜 로그인 나는 부분 에러
- [x] 카카오 로그인 후 탈퇴 시 애플 팝업창 뜨는 이슈 해결 

<br>

### 💻 리뷰어 가이드
> 리뷰어가 작업을 확인할 수 있는 방법, 기대되는 정상적인 동작 내용을 작성

- 카카오 로그인 > 탈퇴 > 애플 팝업창 비노출 로 나타나야 합니다.
- 기존 버전 설치 > 테스트 플라이트 버전 업데이트 > 소셜 로그인 정상동작 확인되야 합니다.
<br>

### 📝 부가 설명
> 작업 중 발생한 고민과 해결 방법, 특정 코드에 대한 의도 및 부가적인 설명 등을 작성

- 서버에서 카카오 탈퇴 시 400번대 에러가 떨어질 수 있습니다. 이거 서버쪽에서 확인해야 할 것 같아요..