### PR TITLE
초대 코드 입력 로직 어색한 부분 수정

### DIFF
--- a/Projects/Features/FeatureFriendList/FeatureFriendListPresentation/Sources/InvitationCodeViewController/InvitationCodeViewModel.swift
+++ b/Projects/Features/FeatureFriendList/FeatureFriendListPresentation/Sources/InvitationCodeViewController/InvitationCodeViewModel.swift
@@ -119,12 +119,18 @@ public final class InvitationCodeViewModel: ViewModelType {
             .disposed(by: disposeBag)
         
         input.didEnterInvitationCode
-            .map { $0.count >= 8 }
+            .withUnretained(self)
+            .flatMap { `self`, invitationCode in
+                self.friendListUseCase.checkInvitationCodeValidation(invitationCode)
+            }
             .bind(to: output.enableConfirmButton)
             .disposed(by: disposeBag)
 
         input.didEnterInvitationCode
-            .map { $0.count <= 8 }
+            .withUnretained(self)
+            .flatMap { `self`, invitationCode in
+                self.friendListUseCase.checkInvitationCodeLengthValidation(invitationCode)
+            }
             .bind(to: output.hideWarningLabel)
             .disposed(by: disposeBag)
         

--- a/Projects/Features/FeatureFriendList/FeatureFriendListUseCase/Sources/DefaultFriendListUseCase.swift
+++ b/Projects/Features/FeatureFriendList/FeatureFriendListUseCase/Sources/DefaultFriendListUseCase.swift
@@ -63,6 +63,18 @@ public final class DefaultFriendListUseCase: FriendListUseCase {
             }
             .asObservable()
     }
+    
+    public func checkInvitationCodeLengthValidation(_ input: String) -> Observable<Bool> {
+        Observable.just( input.count == 8)
+    }
+    
+    public func checkInvitationCodeValidation(_ input: String) -> Observable<Bool> {
+        Observable.zip(
+            checkInvitationCodeLengthValidation(input),
+            checkInvitationCodeDuplicatoin(input)
+        )
+        .map { $0 && !$1 }
+    }
 }
 
 private extension DefaultFriendListUseCase {
@@ -100,5 +112,9 @@ private extension DefaultFriendListUseCase {
                 guard isSuccess else { return .just([]) }
                 return self.fetchFriendList()
             }
+    }
+    
+    func checkInvitationCodeDuplicatoin(_ input: String) -> Observable<Bool> {
+        invitationCode.map( { $0 == input})
     }
 }

--- a/Projects/Features/FeatureFriendList/FeatureFriendListUseCase/Sources/Interface/FriendListUseCase.swift
+++ b/Projects/Features/FeatureFriendList/FeatureFriendListUseCase/Sources/Interface/FriendListUseCase.swift
@@ -13,7 +13,9 @@ import RxSwift
 import CoreEntity
 
 public protocol FriendListUseCase {
+    var invitationCode: Observable<String> { get }
     func fetchFriendList() -> Observable<[FriendEntity]>
     func requestAddingFriend(with invitationCode: String) -> Observable<Bool>
-    var invitationCode: Observable<String> { get }
+    func checkInvitationCodeValidation(_ invitationCode: String) -> Observable<Bool>
+    func checkInvitationCodeLengthValidation(_ invitationCode: String) -> Observable<Bool>
 }


### PR DESCRIPTION
### 🔖 관련 이슈
- #126 

<br> 

### ⚒️ 작업 내역

- [x] 자기 자신의 초대 코드 입력할 경우 확인 버튼 비활성화
- [x] 초대코드 글자 수 8글자 아닐 때 동일하게 경고 라벨 노출

<br>

### 💻 리뷰어 가이드
> 리뷰어가 작업을 확인할 수 있는 방법, 기대되는 정상적인 동작 내용을 작성

- 자기 자신의 초대 코드 입력 > 버튼 비활성화 확인
- 초대코드 길이 8글자 미만, 초과일 때 경고 라벨 노출 확인

<br>

### 📝 부가 설명
    
- 혹시 위 작업 외에 또 의도했던 피드백이 있을까요?