### PR TITLE
사용자 정보 UserDefaults에 저장하는 처리, 앱 기동 후 로그인 처리 미흡한 부분 수정

### DIFF
--- a/Projects/Shared/SharedRepository/Sources/DefaultKeyChainRepository.swift
+++ b/Projects/Shared/SharedRepository/Sources/DefaultKeyChainRepository.swift
@@ -122,7 +122,7 @@ private extension DefaultKeyChainRepository {
         let encodedData = try JSONEncoder().encode(object)
         
         let keychainQuery = keychainQuery(for: .save, key: key, value: encodedData)
-        let alreadyExistingData: Data? = try getBinaryDataFromKeyChain(forKey: key)
+        let alreadyExistingData: Data? = try? getBinaryDataFromKeyChain(forKey: key)
         let isObjectAlreadyExists = alreadyExistingData != nil
 
         if isObjectAlreadyExists {

--- a/Projects/Utils/Sources/UserDefaults/UserDefaultsKeys.swift
+++ b/Projects/Utils/Sources/UserDefaults/UserDefaultsKeys.swift
@@ -9,10 +9,14 @@
 import Foundation
 
 public enum UserDefaultsKeys: String {
+    case userId = "UserId"
     case userLoginType = "UserLoginType"
     case userNickname = "UserNickname"
     case feedVisibility = "FeedVisibility"
     case isAutoLoginActivated = "IsAutoLoginActivated"
+    case birthDate = "UserBirthDate"
+    case genderType = "UserGenderType"
+    case invitationCode = "UserInvitationCode"
     case profileCharacter = "ProfileCharacter"
     
     case isAppFirstlyLaunched = "IsAppFirstlyLaunched"


### PR DESCRIPTION
### 🔖 관련 이슈
- #136 

<br> 

### ⚒️ 작업 내역

- [x] UserInfoUseCase에서 UserDefaults 읽어서 UserInfoEntity 생성하도록 수정
- [x] KeyChain에 인증정보만 저장되도록 수정

<br>

### 💻 리뷰어 가이드
- 혹시 앱 기동 후 아래 기능 정상 동작하는지만 체크 부탁드립니다..!
- 앱 기동 후, 자동 로그인 후 홈화면 진입
- 앱 기동 후, 소셜 로그인 후 홈화면 진입
- 홈 화면 진입 후 로그아웃 > 재로그인 후 홈화면 진입
- 홈 화면 진입 후 탈퇴 > 재로그인 후 홈화면 진입
- 앱 삭제 후 신규 설치 후 위의 내용 재확인
