### PR TITLE
 로그아웃 요청 응답값에 관계없이, 기기에서 로그아웃 처리하도록 수정

### DIFF
--- a/Projects/Features/FeatureSetting/FeatureSettingPresentation/Sources/SettingViewModel.swift
+++ b/Projects/Features/FeatureSetting/FeatureSettingPresentation/Sources/SettingViewModel.swift
@@ -199,12 +199,8 @@ public final class SettingViewModel: ViewModelType {
             .flatMapLatest { `self`, _ in
                 self.userInfoUseCase.requestLogout()
             }
-            .bind(onNext: { isSuccess in
-                if isSuccess {
-                    coordinator?.coordinate(by: .logOutConfirmButtonDidTap)
-                } else {
-                    print("로그아웃 실패 모달 띄우기")
-                }
+            .bind(onNext: { _ in
+                coordinator?.coordinate(by: .logOutConfirmButtonDidTap)
             })
             .disposed(by: disposeBag)
 

--- a/Projects/Shared/SharedUseCase/Sources/Interface/UserInfoUseCase.swift
+++ b/Projects/Shared/SharedUseCase/Sources/Interface/UserInfoUseCase.swift
@@ -25,7 +25,7 @@ public protocol UserInfoUseCase: AnyObject {
     /** 기존 사용자 정보 업데이트(서버 동기화)*/
     func fetchUserInfo(with authInfo: UserAuthInfoEntity) -> Observable<Bool>
     /** 로그아웃 요청 */
-    func requestLogout() -> Observable<Bool>
+    func requestLogout() -> Observable<Void>
     /** 애플 탈퇴 요청*/
     func requestAccountWithdrawl(for loginType: LoginType) -> Observable<Bool>
 }


### PR DESCRIPTION
### 🔖 관련 이슈
- #143 

<br> 

### ⚒️ 작업 내역

- [x] 서버에서의 로그아웃 응답값은 로그로 찍고, 기기 화면에서는 로그인 화면으로 이동 처리

<br>

### 💻 리뷰어 가이드
- 강제로 로그아웃 처리하는 Repository 메소드에서 에러를 던지도록 코드 수정하거나, 
   설정 화면 진입 후 네트워크 끄신 다음에 로그아웃 버튼 터치하셔서 로그아웃 동작하는지 보시면 됩니다.