### PR TITLE
스토리 화면 최초 진입 시 응원 여부 확인하는 처리 추가

### DIFF
--- a/Projects/Core/CoreEntity/Sources/StoryFeedEntity.swift
+++ b/Projects/Core/CoreEntity/Sources/StoryFeedEntity.swift
@@ -13,10 +13,13 @@ public struct StoryFeedEntity {
     
     public let user: UserProfileEntity
     public let stories: [StoryEntity]
+    public let isCheered: Bool
+
     
-    public init(user: UserProfileEntity, stories: [StoryEntity]) {
+    public init(user: UserProfileEntity, stories: [StoryEntity], isCheered: Bool) {
         self.user = user
         self.stories = stories
+        self.isCheered = isCheered
     }
 }
 

--- a/Projects/Core/CoreNetworkService/Sources/DTO/UserProfileDTO.swift
+++ b/Projects/Core/CoreNetworkService/Sources/DTO/UserProfileDTO.swift
@@ -11,4 +11,17 @@ import Foundation
 public struct UserProfileDTO: Codable {
     let nickname: String
     let characterColor, characterShape: Int
+    let isCheered: Bool?
+    
+    public init(
+        nickname: String,
+        characterColor: Int,
+        characterShape: Int,
+        isCheered: Bool? = nil
+    ) {
+        self.nickname = nickname
+        self.characterColor = characterColor
+        self.characterShape = characterShape
+        self.isCheered = isCheered
+    }
 }

--- a/Projects/Core/CoreNetworkService/Sources/DataMapper/StoryFeedEntityMapper.swift
+++ b/Projects/Core/CoreNetworkService/Sources/DataMapper/StoryFeedEntityMapper.swift
@@ -16,7 +16,7 @@ public struct StoryFeedEntityMapper: DataMapper {
 
     public func transform(_ dto: StoryFeedDTO) throws -> StoryFeedEntity {
         guard let color = StoolColor(rawValue: dto.user.characterColor),
-              let shape = StoolShape(rawValue: dto.user.characterColor) else {
+              let shape = StoolShape(rawValue: dto.user.characterShape) else {
             throw NetworkError.dataMappingError
         }
         let nickname = dto.user.nickname
@@ -39,7 +39,8 @@ public struct StoryFeedEntityMapper: DataMapper {
                     shape: shape,
                     date: date
                 )
-            }
+            }, 
+            isCheered: dto.user.isCheered ?? false
         )
     }
 }

--- a/Projects/Core/CoreNetworkService/Sources/Target/LifePoopLocalTarget.swift
+++ b/Projects/Core/CoreNetworkService/Sources/Target/LifePoopLocalTarget.swift
@@ -21,7 +21,6 @@ public enum LifePoopLocalTarget {
     case fetchStoolLog(accessToken: String, userID: Int)
     case fetchStoolLogAtDate(accessToken: String, userID: Int, date: String)
     case postStoolLog(accessToken: String)
-    case fetchFriendsWithStories(accessToken: String)
     case fetchCheeringInfo(accessToken: String, userID: Int, date: String)
     case cheerFriend(accessToken: String, userID: Int)
     case sendInvitationCode(code: String, accessToken: String)
@@ -53,8 +52,6 @@ extension LifePoopLocalTarget: TargetType {
             return "/post/\(userID)/\(date)"
         case .postStoolLog:
             return "/post"
-        case .fetchFriendsWithStories:
-            return "/story"
         case .fetchCheeringInfo(_, let userID, let date):
             return "/user/\(userID)/cheer/\(date)"
         case .cheerFriend(_, let userID):
@@ -80,7 +77,6 @@ extension LifePoopLocalTarget: TargetType {
         switch self {
         case .fetchStoolLog,
                 .fetchStoolLogAtDate,
-                .fetchFriendsWithStories,
                 .fetchCheeringInfo,
                 .fetchUserInfo,
                 .fetchFriendList,
@@ -106,7 +102,6 @@ extension LifePoopLocalTarget: TargetType {
         case .fetchStoolLog(let accessToken, _),
              .fetchStoolLogAtDate(let accessToken, _, _),
              .postStoolLog(let accessToken),
-             .fetchFriendsWithStories(let accessToken),
              .fetchCheeringInfo(let accessToken, _, _),
              .cheerFriend(let accessToken, _),
              .fetchUserInfo(let accessToken),

--- a/Projects/Features/FeatureHome/FeatureHomeCoordinator/Sources/DefaultHomeCoordinator.swift
+++ b/Projects/Features/FeatureHome/FeatureHomeCoordinator/Sources/DefaultHomeCoordinator.swift
@@ -59,8 +59,8 @@ public final class DefaultHomeCoordinator: HomeCoordinator {
                 self?.startSettingCoordinatorFlow()
             case .reportButtonDidTap:
                 self?.pushReportViewController()
-            case .storyFeedButtonDidTap(let stories):
-                self?.presentFriendStoolStoryViewController(stories: stories, animated: true)
+            case .storyFeedButtonDidTap(let stories, let isCheered):
+                self?.presentFriendStoolStoryViewController(stories: stories, isCheered: isCheered, animated: true)
             case .storyCloseButtonDidTap:
                 self?.dismissFriendStoolStoryViewController(animated: true)
             }
@@ -84,9 +84,10 @@ private extension DefaultHomeCoordinator {
     
     func presentFriendStoolStoryViewController(
         stories: [StoryEntity],
+        isCheered: Bool,
         animated: Bool
     ) {
-        let viewModel = FriendStoolStoryViewModel(coordinator: self, stories: stories)
+        let viewModel = FriendStoolStoryViewModel(coordinator: self, stories: stories, isCheered: isCheered)
         let viewController = FriendStoolStoryViewController()
         viewController.bind(viewModel: viewModel)
         viewController.modalPresentationStyle = .overFullScreen

--- a/Projects/Features/FeatureHome/FeatureHomeCoordinatorInterface/Sources/HomeCoordinatorAction.swift
+++ b/Projects/Features/FeatureHome/FeatureHomeCoordinatorInterface/Sources/HomeCoordinatorAction.swift
@@ -19,6 +19,6 @@ public enum HomeCoordinateAction {
     case stoolLogButtonDidTap(stoolLogsRelay: BehaviorRelay<[StoolLogEntity]>)
     case settingButtonDidTap
     case reportButtonDidTap
-    case storyFeedButtonDidTap(stories: [StoryEntity])
+    case storyFeedButtonDidTap(stories: [StoryEntity], isCheered: Bool)
     case storyCloseButtonDidTap
 }

--- a/Projects/Features/FeatureHome/FeatureHomePresentation/Sources/FriendStoolStoryScene/FriendStoolStoryViewController.swift
+++ b/Projects/Features/FeatureHome/FeatureHomePresentation/Sources/FriendStoolStoryScene/FriendStoolStoryViewController.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2023 Lifepoo. All rights reserved.
 //
 
+import AVFoundation
 import UIKit
 
 import RxCocoa
@@ -92,6 +93,9 @@ public final class FriendStoolStoryViewController: LifePoopViewController, ViewT
             .disposed(by: disposeBag)
         
         cheeringButton.rx.tap
+            .do(onNext: { _ in
+                AudioServicesPlaySystemSound(kSystemSoundID_Vibrate)
+            })
             .bind(to: input.cheeringButtonDidTap)
             .disposed(by: disposeBag)
     }

--- a/Projects/Features/FeatureHome/FeatureHomePresentation/Sources/StoolLogCollectionView/StoolLogHeaderViewModel.swift
+++ b/Projects/Features/FeatureHome/FeatureHomePresentation/Sources/StoolLogCollectionView/StoolLogHeaderViewModel.swift
@@ -119,13 +119,12 @@ public final class StoolLogHeaderViewModel: ViewModelType {
             .bind(to: output.showEmptyCheeringInfo)
             .disposed(by: disposeBag)
         
-        // TODO: 터치한 친구(유저)에 대한 힘주기 가능 여부를 최초로 알 수 있어야 함
         input.storyFeedCellDidTap
             .map { $0.item }
             .withLatestFrom(state.storyFeeds) { $1[$0] }
             .bind(onNext: { storyFeed in
                 coordinator?.coordinate(
-                    by: .storyFeedButtonDidTap(stories: storyFeed.stories)
+                    by: .storyFeedButtonDidTap(stories: storyFeed.stories, isCheered: storyFeed.isCheered)
                 )
             })
             .disposed(by: disposeBag)


### PR DESCRIPTION
### 🔖 관련 이슈
- #153 

<br> 

### ⚒️ 작업 내역

- [x] DTO 수정
- [x] 스토리 힘주기 요청 후 정상 응답 확인
- [ ] 정상 응답 확인 후 홈화면 헤더 상태 변경

<br>

### 💻 리뷰어 가이드
- 단순히 isCheered 값 읽도록 처리만 했습니다.
- 현재 서버에서 응원하기 201 응답 확인 이후에도 계속해서 isCheered가 false로 나와서, 서버에서 먼저 확인하고 기능 동작 확인해야 할 것 같아요