### PR TITLE
CI 과정 중 Testflight 배포 단계에서 발생하는 에러 수정

### DIFF
--- a/Projects/Features/FeatureHome/FeatureHomeRepository/Project.swift
+++ b/Projects/Features/FeatureHome/FeatureHomeRepository/Project.swift
@@ -17,6 +17,7 @@ let project = Project.makeModule(
         .Project.module(.Core(.CoreEntity)).dependency,
         .Project.module(.Core(.CoreNetworkService)).dependency,
         .Project.module(.Features(.Home, .UseCase)).dependency,
+        .Project.module(.Logger).dependency,
         .Project.module(.Utils).dependency,
         .SPM.RxSwift.dependency
     ]

--- a/Projects/Features/FeatureLogin/FeatureLoginRepository/Project.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginRepository/Project.swift
@@ -18,6 +18,7 @@ let project = Project.makeModule(
         .Project.module(.Core(.CoreEntity)).dependency,
         .Project.module(.Core(.CoreNetworkService)).dependency,
         .Project.module(.Features(.Login, .UseCase)).dependency,
+        .Project.module(.Logger).dependency,
         .Project.module(.Utils).dependency,
         .SPM.RxSwift.dependency
     ]

--- a/Projects/Features/FeatureStoolLog/FeatureStoolLogRepository/Project.swift
+++ b/Projects/Features/FeatureStoolLog/FeatureStoolLogRepository/Project.swift
@@ -17,6 +17,7 @@ let project = Project.makeModule(
         .Project.module(.Core(.CoreEntity)).dependency,
         .Project.module(.Core(.CoreNetworkService)).dependency,
         .Project.module(.Features(.StoolLog, .UseCase)).dependency,
+        .Project.module(.Shared(.SharedUseCase)).dependency,
         .Project.module(.Utils).dependency,
         .SPM.RxSwift.dependency
     ]


### PR DESCRIPTION
### 🔖 관련 이슈
- #155 

<br> 

### ⚒️ 작업 내역

- [x] 

<br>

### 💻 리뷰어 가이드

1. Actions -> Build-And-Deploy-Testflight에 대해 branch를 #155로 설정후 run workflow 실행
2. 이후 테스트플라이트가 정상 배포되는지 확인

<br>

### 📝 부가 설명

FeatureStoolLogRepository 모듈 컴파일 후,
CoreAuthentication를 auto-linking 할 수 없다는 에러 로그 발생하며 배포 실패했습니다.

FeatureStoolLogRepository 모듈에 의존성 설정이 잘못되어있는 것으로 추정하고
워크스페이스에 설정된 의존성과 Tuist 메니페스트 파일을 대조했고,
SharedUseCase를 import함에도 불구하고 해당 의존성이 메니페스트파일에는 존재하지 않음을 확인했습니다.

따라서 FeatureStoolLogRepository에 SharedUseCase 모듈 의존성을 직접 추가해줬고,
이후 테스트플라이트 배포에 성공하는 것을 확인했습니다.

<br> 

### 📑 첨부 자료


```
Could not find or use auto-linked framework 'CoreAuthentication'
```

![CleanShot 2023-11-05 at 17 15 38](https://github.com/LifePoop/LifePoop_iOS/assets/57667738/a79de4e5-c7a9-457b-82e3-d61a1b88e68f)
