### PR TITLE
힘주기 요청 후 버튼 비활성화 처리 및 홈화면 헤더 상태 변경

### DIFF
--- a/Projects/Core/CoreEntity/Sources/UserProfileEntity.swift
+++ b/Projects/Core/CoreEntity/Sources/UserProfileEntity.swift
@@ -10,11 +10,13 @@ import Foundation
 
 public struct UserProfileEntity {
     
-    public init(nickname: String, profileCharacter: ProfileCharacter) {
+    public init(userId: Int, nickname: String, profileCharacter: ProfileCharacter) {
+        self.userId = userId
         self.nickname = nickname
         self.profileCharacter = profileCharacter
     }
     
+    public let userId: Int
     public let nickname: String
     public let profileCharacter: ProfileCharacter
 }

--- a/Projects/Core/CoreNetworkService/Sources/DTO/UserProfileDTO.swift
+++ b/Projects/Core/CoreNetworkService/Sources/DTO/UserProfileDTO.swift
@@ -9,16 +9,27 @@
 import Foundation
 
 public struct UserProfileDTO: Codable {
+    let userId: Int
     let nickname: String
     let characterColor, characterShape: Int
     let isCheered: Bool?
     
+    enum CodingKeys: String, CodingKey {
+        case userId = "id"
+        case nickname
+        case characterColor
+        case characterShape
+        case isCheered
+    }
+    
     public init(
+        userId: Int,
         nickname: String,
         characterColor: Int,
         characterShape: Int,
         isCheered: Bool? = nil
     ) {
+        self.userId = userId
         self.nickname = nickname
         self.characterColor = characterColor
         self.characterShape = characterShape

--- a/Projects/Core/CoreNetworkService/Sources/DataMapper/CheeringInfoEntityMapper.swift
+++ b/Projects/Core/CoreNetworkService/Sources/DataMapper/CheeringInfoEntityMapper.swift
@@ -24,6 +24,7 @@ public struct CheeringInfoEntityMapper: DataMapper {
                 }
                 
                 return UserProfileEntity(
+                    userId: $0.userId,
                     nickname: $0.nickname,
                     profileCharacter: ProfileCharacter(
                         color: color,

--- a/Projects/Core/CoreNetworkService/Sources/DataMapper/StoryFeedEntityMapper.swift
+++ b/Projects/Core/CoreNetworkService/Sources/DataMapper/StoryFeedEntityMapper.swift
@@ -21,9 +21,12 @@ public struct StoryFeedEntityMapper: DataMapper {
         }
         let nickname = dto.user.nickname
         return StoryFeedEntity(
-            user: UserProfileEntity(nickname: nickname, profileCharacter: ProfileCharacter(
-                color: color,
-                shape: shape
+            user: UserProfileEntity(
+                userId: dto.user.userId,
+                nickname: nickname,
+                profileCharacter: ProfileCharacter(
+                    color: color,
+                    shape: shape
             )),
             stories: try dto.stories.map {
                 guard let color = StoolColor(rawValue: $0.color),

--- a/Projects/Core/CoreNetworkService/Sources/DataMapper/UserProfileDTOMapper.swift
+++ b/Projects/Core/CoreNetworkService/Sources/DataMapper/UserProfileDTOMapper.swift
@@ -16,6 +16,7 @@ public struct UserProfileDTOMapper: DataMapper {
 
     public func transform(_ entity: UserProfileEntity) throws -> UserProfileDTO {
         return UserProfileDTO(
+            userId: entity.userId,
             nickname: entity.nickname,
             characterColor: entity.profileCharacter.color.rawValue,
             characterShape: entity.profileCharacter.shape.rawValue

--- a/Projects/Features/FeatureHome/FeatureHomeCoordinator/Sources/DefaultHomeCoordinator.swift
+++ b/Projects/Features/FeatureHome/FeatureHomeCoordinator/Sources/DefaultHomeCoordinator.swift
@@ -59,8 +59,13 @@ public final class DefaultHomeCoordinator: HomeCoordinator {
                 self?.startSettingCoordinatorFlow()
             case .reportButtonDidTap:
                 self?.pushReportViewController()
-            case .storyFeedButtonDidTap(let stories, let isCheered):
-                self?.presentFriendStoolStoryViewController(stories: stories, isCheered: isCheered, animated: true)
+            case .storyFeedButtonDidTap(let friendUserId, let stories, let isCheered):
+                self?.presentFriendStoolStoryViewController(
+                    friendUserId: friendUserId,
+                    stories: stories,
+                    isCheered: isCheered,
+                    animated: true
+                )
             case .storyCloseButtonDidTap:
                 self?.dismissFriendStoolStoryViewController(animated: true)
             }
@@ -83,11 +88,17 @@ private extension DefaultHomeCoordinator {
     }
     
     func presentFriendStoolStoryViewController(
+        friendUserId: Int,
         stories: [StoryEntity],
         isCheered: Bool,
         animated: Bool
     ) {
-        let viewModel = FriendStoolStoryViewModel(coordinator: self, stories: stories, isCheered: isCheered)
+        let viewModel = FriendStoolStoryViewModel(
+            coordinator: self,
+            friendUserId: friendUserId,
+            stories: stories,
+            isCheered: isCheered
+        )
         let viewController = FriendStoolStoryViewController()
         viewController.bind(viewModel: viewModel)
         viewController.modalPresentationStyle = .overFullScreen

--- a/Projects/Features/FeatureHome/FeatureHomeCoordinatorInterface/Sources/HomeCoordinatorAction.swift
+++ b/Projects/Features/FeatureHome/FeatureHomeCoordinatorInterface/Sources/HomeCoordinatorAction.swift
@@ -19,6 +19,6 @@ public enum HomeCoordinateAction {
     case stoolLogButtonDidTap(stoolLogsRelay: BehaviorRelay<[StoolLogEntity]>)
     case settingButtonDidTap
     case reportButtonDidTap
-    case storyFeedButtonDidTap(stories: [StoryEntity], isCheered: Bool)
+    case storyFeedButtonDidTap(friendUserId: Int, stories: [StoryEntity], isCheered: Bool)
     case storyCloseButtonDidTap
 }

--- a/Projects/Features/FeatureHome/FeatureHomePresentation/Sources/FriendStoolStoryScene/FriendStoolStoryViewModel.swift
+++ b/Projects/Features/FeatureHome/FeatureHomePresentation/Sources/FriendStoolStoryScene/FriendStoolStoryViewModel.swift
@@ -52,11 +52,16 @@ public final class FriendStoolStoryViewModel: ViewModelType {
         
     private var disposeBag = DisposeBag()
     
-    public init(coordinator: HomeCoordinator?, stories: [StoryEntity], isCheered: Bool) {
-        bind(coordinator: coordinator, stories: stories, isCheered: isCheered)
+    public init(
+        coordinator: HomeCoordinator?,
+        friendUserId: Int,
+        stories: [StoryEntity],
+        isCheered: Bool
+    ) {
+        bind(coordinator: coordinator, friendUserId: friendUserId, stories: stories, isCheered: isCheered)
     }
     
-    private func bind(coordinator: HomeCoordinator?, stories: [StoryEntity], isCheered: Bool) {
+    private func bind(coordinator: HomeCoordinator?, friendUserId: Int, stories: [StoryEntity], isCheered: Bool) {
         
         Observable.just(isCheered)
             .withUnretained(self)
@@ -147,14 +152,12 @@ public final class FriendStoolStoryViewModel: ViewModelType {
             .disposed(by: disposeBag)
         
         input.cheeringButtonDidTap
-            .withLatestFrom(output.updateShownStory)
-            .map { $0.id }
             .withUnretained(self)
             .do(onNext: { `self`, _ in
                 self.output.showLoadingIndicator.accept(true)
             })
-            .flatMapLatest { `self`, id in
-                self.cheeringInfoUseCase.requestCheering(withIdOf: id)
+            .flatMapLatest { `self`, _ in
+                self.cheeringInfoUseCase.requestCheering(withIdOf: friendUserId)
             }
             .withUnretained(self)
             .do(onNext: { `self`, _ in

--- a/Projects/Features/FeatureHome/FeatureHomePresentation/Sources/FriendStoolStoryScene/FriendStoolStoryViewModel.swift
+++ b/Projects/Features/FeatureHome/FeatureHomePresentation/Sources/FriendStoolStoryScene/FriendStoolStoryViewModel.swift
@@ -173,7 +173,10 @@ public final class FriendStoolStoryViewModel: ViewModelType {
                 let cheeringButtonText = isSuccess ? LocalizableString.doneBoost
                                                    : LocalizableString.boost
                 self.output.updateCheeringButtonText.accept(cheeringButtonText)
-
+                
+                if isSuccess {
+                    NotificationCenter.default.post(name: .updateCheering, object: friendUserId)
+                }
             })
             .disposed(by: disposeBag)
     }

--- a/Projects/Features/FeatureHome/FeatureHomePresentation/Sources/StoolLogCollectionView/StoolLogHeaderViewModel.swift
+++ b/Projects/Features/FeatureHome/FeatureHomePresentation/Sources/StoolLogCollectionView/StoolLogHeaderViewModel.swift
@@ -123,8 +123,13 @@ public final class StoolLogHeaderViewModel: ViewModelType {
             .map { $0.item }
             .withLatestFrom(state.storyFeeds) { $1[$0] }
             .bind(onNext: { storyFeed in
+                
                 coordinator?.coordinate(
-                    by: .storyFeedButtonDidTap(stories: storyFeed.stories, isCheered: storyFeed.isCheered)
+                    by: .storyFeedButtonDidTap(
+                        friendUserId: storyFeed.user.userId,
+                        stories: storyFeed.stories,
+                        isCheered: storyFeed.isCheered
+                    )
                 )
             })
             .disposed(by: disposeBag)

--- a/Projects/Utils/Sources/NotificationCenter/NotificationName.swift
+++ b/Projects/Utils/Sources/NotificationCenter/NotificationName.swift
@@ -10,4 +10,5 @@ import Foundation
 
 public extension NSNotification.Name {
     static let resetLogin = NSNotification.Name("ResetLogin")
+    static let updateCheering = NSNotification.Name("CheeringFriend")
 }


### PR DESCRIPTION
### 🔖 관련 이슈
- #153 

<br> 

### ⚒️ 작업 내역

- [x] 힘주기 요청 후 isCheered값 정상으로 바뀌는 것 확인
- [x] 힘주기 성공 후 홈화면 헤더 상태 변경 

<br>

### 💻 리뷰어 가이드
- 힘주기 요청>스토리 화면에서 버튼 비활성화 및 모든 텍스트 라벨 바뀐 것 확인
- 힘주기 요청>성공 후 스토리 화면 닫기>해당 스토리 재진입 후 응원 완료 표시 확인
    - refresh 하지 않은 상태에서도 상태가 변경되었는 지 확인되면 됩니다. 

** 빠른 처리를 위해 NotificationCenter을 사용해서 홈화면의 상태를 바꾸도록 우선 처리했는데 보시고 좀 어색하다 싶음 추후 바꿀께요