### PR TITLE
로그인 코드 리팩토링, 일부 UX 개선

### DIFF
--- a/Projects/DesignSystem/Sources/Component/UIButton/LifePoopButton.swift
+++ b/Projects/DesignSystem/Sources/Component/UIButton/LifePoopButton.swift
@@ -10,7 +10,7 @@ import UIKit
 
 import SnapKit
 
-public final class LifePoopButton: PaddingButton {
+public class LifePoopButton: PaddingButton {
     
     private var loadingIndicator: UIActivityIndicatorView = {
         let activityIndicator = UIActivityIndicatorView(style: .medium)

--- a/Projects/DesignSystem/Sources/Component/UIButton/LoginButton.swift
+++ b/Projects/DesignSystem/Sources/Component/UIButton/LoginButton.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-public final class LoginButton: UIButton {
+public final class LoginButton: LifePoopButton {
     
     private let title: String
     private let iconImage: UIImage?
@@ -21,7 +21,7 @@ public final class LoginButton: UIButton {
         self.baseBackgroundColor = backgroundColor
         self.fontColor = fontColor
         
-        super.init(frame: .zero)
+        super.init()
 
         configure()
     }

--- a/Projects/DesignSystem/Sources/Component/UIButton/LoginButton.swift
+++ b/Projects/DesignSystem/Sources/Component/UIButton/LoginButton.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-public final class LoginButton: LifePoopButton {
+public final class LoginButton: UIButton {
     
     private let title: String
     private let iconImage: UIImage?
@@ -21,9 +21,9 @@ public final class LoginButton: LifePoopButton {
         self.baseBackgroundColor = backgroundColor
         self.fontColor = fontColor
         
-        super.init()
+        super.init(frame: .zero)
 
-        configure()
+        configureUI()
     }
     
     @available(*, unavailable)
@@ -31,20 +31,35 @@ public final class LoginButton: LifePoopButton {
         fatalError("init(coder:) has not been implemented")
     }
     
-    private func configure() {
+    private func configureUI() {
         var config = UIButton.Configuration.filled()
         config.image = iconImage
         config.imagePlacement = .leading
         config.imagePadding = 10
         config.contentInsets = .init(top: 17.5, leading: 17.5, bottom: 17.5, trailing: 17.5)
-        config.cornerStyle = .large
         
         var attributedTitleText = AttributedString(title)
         attributedTitleText.font = .systemFont(ofSize: 16, weight: .bold)
-        attributedTitleText.foregroundColor = fontColor
         config.attributedTitle = attributedTitleText
 
         config.baseBackgroundColor = baseBackgroundColor
+        config.baseForegroundColor = fontColor
+        config.background.cornerRadius = 12
+                
         configuration = config
+    }
+}
+
+// MARK: Loading Indicator
+
+public extension LoginButton {
+    func showLoadingIndicator() {
+        isEnabled = false
+        configuration?.showsActivityIndicator = true
+    }
+    
+    func hideLoadingIndicator() {
+        isEnabled = true
+        configuration?.showsActivityIndicator = false
     }
 }

--- a/Projects/Features/FeatureLogin/FeatureLoginCoordinator/Sources/DefaultLoginCoordinator.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginCoordinator/Sources/DefaultLoginCoordinator.swift
@@ -50,9 +50,7 @@ public final class DefaultLoginCoordinator: LoginCoordinator {
                 self?.showLoginViewController(animated: false)
             case .showDetailForm(let title, let detailText):
                 self?.showDocumentViewController(title: title, detailText: detailText)
-            case .didTapKakaoLoginButton(let authInfo):
-                self?.showNicknameViewController(with: authInfo)
-            case .didTapAppleLoginButton(let authInfo):
+            case .didTapLoginButton(let authInfo):
                 self?.showNicknameViewController(with: authInfo)
             case .finishLoginFlow:
                 self?.finishFlow()

--- a/Projects/Features/FeatureLogin/FeatureLoginCoordinatorInterface/Sources/LoginCoordinateAction.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginCoordinatorInterface/Sources/LoginCoordinateAction.swift
@@ -16,7 +16,6 @@ public enum LoginCoordinateAction {
     case showLoginScene
     case showDetailForm(title: String, detailText: String)
     case popCurrentScene
-    case didTapAppleLoginButton(userAuthInfo: OAuthTokenInfo)
-    case didTapKakaoLoginButton(userAuthInfo: OAuthTokenInfo)
+    case didTapLoginButton(userAuthInfo: OAuthTokenInfo)
     case finishLoginFlow
 }

--- a/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/LoginScene/LoginViewController.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/LoginScene/LoginViewController.swift
@@ -92,10 +92,12 @@ public final class LoginViewController: LifePoopViewController, ViewType {
             .disposed(by: disposeBag)
 
         kakaoTalkLoginButon.rx.tap
+            .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance)
             .bind(to: input.didTapKakaoLoginButton)
             .disposed(by: disposeBag)
         
         appleLoginButton.rx.tap
+            .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance)
             .bind(to: input.didTapAppleLoginButton)
             .disposed(by: disposeBag)
         
@@ -142,6 +144,26 @@ public final class LoginViewController: LifePoopViewController, ViewType {
         
         output.subLabelText
             .bind(to: subLabel.rx.text)
+            .disposed(by: disposeBag)
+        
+        output.showLoadingIndicator
+            .asSignal()
+            .withUnretained(self)
+            .emit(onNext: { `self`, indicatorTarget in
+                let showLoadingIndicator = indicatorTarget.activate
+                
+                var targetButton: LoginButton
+                switch indicatorTarget.loginType {
+                case .apple: targetButton = self.appleLoginButton
+                case .kakao: targetButton = self.kakaoTalkLoginButon
+                }
+                
+                if showLoadingIndicator {
+                    targetButton.showLoadingIndicator()
+                } else {
+                    targetButton.hideLoadingIndicator()
+                }
+            })
             .disposed(by: disposeBag)
         
         output.showErrorMessage

--- a/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/LoginScene/LoginViewController.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/LoginScene/LoginViewController.swift
@@ -21,6 +21,7 @@ public final class LoginViewController: LifePoopViewController, ViewType {
         let pageControl = UIPageControl()
         pageControl.currentPageIndicatorTintColor = ColorAsset.primary.color
         pageControl.pageIndicatorTintColor = ColorAsset.gray300.color
+        pageControl.isUserInteractionEnabled = false
         return pageControl
     }()
     

--- a/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/LoginScene/LoginViewController.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/LoginScene/LoginViewController.swift
@@ -168,8 +168,8 @@ public final class LoginViewController: LifePoopViewController, ViewType {
             .disposed(by: disposeBag)
         
         output.showErrorMessage
-            .asDriver(onErrorJustReturn: "")
-            .drive(with: self, onNext: { `self`, error in
+            .asSignal()
+            .emit(with: self, onNext: { `self`, error in
                 self.showSystemAlert(title: "Login Error", message: error)
             })
             .disposed(by: disposeBag)

--- a/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/LoginScene/LoginViewController.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/LoginScene/LoginViewController.swift
@@ -167,8 +167,9 @@ public final class LoginViewController: LifePoopViewController, ViewType {
             .disposed(by: disposeBag)
         
         output.showErrorMessage
-            .bind(onNext: { error in
-                print("\(error) 확인 -> 추후 확인 후 토스트 메시지 혹은 다른 시각적 요소 출력으로 대체")
+            .asDriver(onErrorJustReturn: "")
+            .drive(with: self, onNext: { `self`, error in
+                self.showSystemAlert(title: "Login Error", message: error)
             })
             .disposed(by: disposeBag)
     }
@@ -178,24 +179,24 @@ public final class LoginViewController: LifePoopViewController, ViewType {
         
         let frameHeight = view.frame.height
         let frameWidth = view.frame.width
-
+        
         view.addSubview(bannerCollectionView)
         view.addSubview(subLabel)
         view.addSubview(pageControl)
         view.addSubview(kakaoTalkLoginButon)
         view.addSubview(appleLoginButton)
-
+        
         bannerCollectionView.snp.makeConstraints { make in
             make.bottom.equalTo(view.snp.centerY).offset(51)
             make.leading.trailing.equalToSuperview()
             make.height.equalTo(frameWidth * 0.8)
         }
-
+        
         subLabel.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
             make.top.equalTo(bannerCollectionView.snp.bottom).offset(frameHeight * 0.03)
         }
-
+        
         pageControl.snp.makeConstraints { make in
             make.top.equalTo(subLabel.snp.bottom).offset(frameHeight * 0.03)
             make.centerX.equalToSuperview()

--- a/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/LoginScene/LoginViewModel.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/LoginScene/LoginViewModel.swift
@@ -67,12 +67,6 @@ public final class LoginViewModel: ViewModelType {
                 self?.output.showLoadingIndicator.accept(.init(loginType: .kakao, activate: false))
             })
             .share()
-   
-        fetchKakaoToken
-            .compactMap { $0.error }
-            .map { $0.localizedDescription }
-            .bind(to: output.showErrorMessage)
-            .disposed(by: disposeBag)
         
         let fetchAppleToken = input.didTapAppleLoginButton
             .withUnretained(self)
@@ -86,12 +80,6 @@ public final class LoginViewModel: ViewModelType {
                 self?.output.showLoadingIndicator.accept(.init(loginType: .apple, activate: false))
             })
             .share()
-        
-        fetchAppleToken
-            .compactMap { $0.error }
-            .map { $0.localizedDescription }
-            .bind(to: output.showErrorMessage)
-            .disposed(by: disposeBag)
         
         let loginResult = Observable.merge(
             fetchKakaoToken.compactMap { $0.element }.compactMap { $0 },
@@ -114,12 +102,15 @@ public final class LoginViewModel: ViewModelType {
                 }
             })
             .disposed(by: disposeBag)
-
-        loginResult
-            .compactMap { $0.error }
-            .map { $0.localizedDescription }
-            .bind(to: output.showErrorMessage)
-            .disposed(by: disposeBag)
+        
+        Observable.merge(
+            fetchAppleToken.compactMap { $0.error },
+            fetchKakaoToken.compactMap { $0.error },
+            loginResult.compactMap { $0.error }
+        )
+        .map { $0.localizedDescription }
+        .bind(to: output.showErrorMessage)
+        .disposed(by: disposeBag)
 
         input.didChangeBannerImageIndex
             .withUnretained(self)

--- a/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/LoginScene/LoginViewModel.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/LoginScene/LoginViewModel.swift
@@ -84,7 +84,7 @@ public final class LoginViewModel: ViewModelType {
                                     by: .didTapKakaoLoginButton(userAuthInfo: oAuthTokenInfo)
                                 )
                 case .failure(let error):
-                    self?.output.showErrorMessage.accept(error.localizedDescription)
+                    self?.output.showErrorMessage.accept(error.description)
                 }
             })
             .disposed(by: disposeBag)

--- a/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/Interface/LoginUseCase.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/Interface/LoginUseCase.swift
@@ -10,6 +10,11 @@ import RxSwift
 
 import CoreEntity
 
+public enum LoginResult {
+    case success(authInfo: UserAuthInfoEntity)
+    case failure(loginError: LoginError)
+}
+
 public protocol LoginUseCase {
 
     /** 앱 설치 후 최초 기동 시에 기존에 저장된 사용자 인증 정보 초기화*/
@@ -17,7 +22,7 @@ public protocol LoginUseCase {
     /** 현재 로컬 기기에 저장된 사용자 인증 정보로 자동 로그인 처리 요청 */
     func requestAutoLoginWithExistingUserInfo() -> Observable<Bool>
     /** OAuth 토큰 정보로 Lifepoo Access Token, Refresh Token 획득 및 로그인 처리 요청 */
-    func requestLogin(with userInfo: OAuthTokenInfo) -> Observable<Result<Bool, LoginError>>
+    func requestLogin(with userInfo: OAuthTokenInfo) -> Observable<Bool>
     /** 소셜 로그인(Apple, Kakao) OAuth Access Token 요청*/
     func fetchOAuthAccessToken(for loginType: LoginType) -> Observable<OAuthTokenInfo?>
 }

--- a/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/LoginError.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/LoginError.swift
@@ -12,9 +12,7 @@ public enum LoginError: Error, CustomStringConvertible {
     
     case oAuthLoginFailed
     case userNotExists
-    case failedFetchingUserInfo
     case updatedAuthInfoNil
-    case otherNetworkError(error: Error)
     
     public var description: String {
         switch self {
@@ -22,12 +20,8 @@ public enum LoginError: Error, CustomStringConvertible {
             return "소셜 로그인 실패"
         case .userNotExists:
             return "해당 사용자가 존재하지 않음. 회원가입 필요"
-        case .failedFetchingUserInfo:
-            return "사용자 정보 불러오기 실패"
         case .updatedAuthInfoNil:
             return "업데이트된 인증정보가 존재하지 않음. Repository 리턴값 재확인 필요"
-        case .otherNetworkError(let error):
-            return "알 수 없는 네트워크 에러\n(\(error))"
         }
     }
 }

--- a/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/RepositoryInterface/LoginRepository.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/RepositoryInterface/LoginRepository.swift
@@ -13,6 +13,6 @@ import Utils
 
 public protocol LoginRepository: AnyObject {
     
-    func requestAuthInfoWithOAuthAccessToken(with userAuthInfo: OAuthTokenInfo) -> Single<Result<UserAuthInfoEntity?, LoginError>>
+    func requestAuthInfoWithOAuthAccessToken(with userAuthInfo: OAuthTokenInfo) -> Single<LoginResult>
     func fetchOAuthAccessToken(for loginType: LoginType) -> Single<String>
 }

--- a/Projects/Logger/Sources/Rx+log.swift
+++ b/Projects/Logger/Sources/Rx+log.swift
@@ -1,0 +1,38 @@
+//
+//  Rx+log.swift
+//  Logger
+//
+//  Created by Lee, Joon Woo on 2023/11/11.
+//  Copyright © 2023 Lifepoo. All rights reserved.
+//
+
+import Foundation
+import OSLog
+
+import RxSwift
+
+public extension ObservableType {
+    func log(message: String, category: OSLog.LogCategory, printElement: Bool = false) -> Observable<Element> {
+        return self.logErrorIfDetected(category: category, type: .error)
+            .do(onNext: { element in
+            let meesage = printElement ? "\(message)\nvalue:\(element)" : message
+            Logger.log(message: message, category: category, type: .debug)
+        })
+    }
+}
+
+public extension PrimitiveSequence where Trait == SingleTrait {
+    func log(message: String, category: OSLog.LogCategory, printElement: Bool = false) -> Single<Element> {
+        return self.asObservable()
+            .log(message: message, category: category, printElement: printElement)
+            .asSingle()
+    }
+}
+
+public extension PrimitiveSequence where Trait == CompletableTrait, Element == Never {
+    func log(message: String, category: OSLog.LogCategory, printElement: Bool = false) -> Completable {
+        return self.asObservable()
+            .log(message: message, category: category, printElement: printElement)
+            .asCompletable()
+    }
+}

--- a/Projects/Shared/SharedUseCase/Sources/DefaultUserInfoUseCase.swift
+++ b/Projects/Shared/SharedUseCase/Sources/DefaultUserInfoUseCase.swift
@@ -247,6 +247,7 @@ private extension DefaultUserInfoUseCase {
             .concat(userDefaultsRepository.updateValue(for: .userLoginType, with: userInfo.authInfo.loginType))
             .concat(userDefaultsRepository.updateValue(for: .profileCharacter, with: userInfo.profileCharacter))
             .concat(userDefaultsRepository.updateValue(for: .userId, with: userInfo.userId))
+            .concat(userDefaultsRepository.updateValue(for: .genderType, with: userInfo.genderType))
             .concat(userDefaultsRepository.updateValue(for: .birthDate, with: userInfo.birthDate))
             .concat(userDefaultsRepository.updateValue(for: .invitationCode, with: userInfo.invitationCode))
             .logErrorIfDetected(category: .authentication)

--- a/Projects/Utils/Resources/Localizable.strings
+++ b/Projects/Utils/Resources/Localizable.strings
@@ -28,6 +28,7 @@
 "hours" = "시간";
 "minutes" = "분";
 "ago" = "전";
+"confirm" = "확인";
 
 /* 온보딩 */
 "logYourStools" = "나의 변을 기록하고";

--- a/Projects/Utils/Sources/Extension/UIViewController+showSystemAlert.swift
+++ b/Projects/Utils/Sources/Extension/UIViewController+showSystemAlert.swift
@@ -1,0 +1,28 @@
+//
+//  UIViewController+showSystemAlert.swift
+//  Utils
+//
+//  Created by Lee, Joon Woo on 2023/11/07.
+//  Copyright © 2023 Lifepoo. All rights reserved.
+//
+
+import UIKit
+
+public extension UIViewController {
+
+    func showSystemAlert(title: String, message: String, completion: (() -> Void)? = nil) {
+        let alert = UIAlertController(
+            title: title,
+            message: message,
+            preferredStyle: UIAlertController.Style.alert
+        )
+        
+        let defaultAction = UIAlertAction(
+            title: LocalizableString.confirm,
+            style: UIAlertAction.Style.default
+        )
+        alert.addAction(defaultAction)
+        
+        present(alert, animated: false, completion: completion)
+    }
+}


### PR DESCRIPTION
### 🔖 관련 이슈
- #148

<br> 

### ⚒️ 작업 내역

- 로그인 관련 에러 발생 시 system alert 띄우도록 처리
- Repository, UseCase, ViewModel 코드 리팩토링
- 로그인 버튼 터치 후, 응답 수신할 때 까지 버튼 차단 처리
- PageControl의 터치 차단

<br>

### 💻 리뷰어 가이드
- DefaultLoginRepository에서 의도적으로 throw Error을 한 후, alert가 뜨는지 확인하면 됩니다.
- 로그인 버튼 터치 후, 버튼 터치가 차단된 것이 확인되면 됩니다.

### 📝 부가 설명
- 일부 중복코드 혹은 Single<Result<A,Error>>과 같이 작성된 부분을 개선
- DefaultLoginUseCase 내에서 로그 찍는 부분 코드가 보기 지저분한 부분 개선
