### PR TITLE
친구 추가 성공 후 홈 화면으로 돌아갈 시, 별도의 리프레시 없어도 갱신된 스토리 목록을 보여주도록 변경

### DIFF
--- a/Projects/Features/FeatureFriendList/FeatureFriendListCoordinator/Sources/DefaultFriendListCoordinator.swift
+++ b/Projects/Features/FeatureFriendList/FeatureFriendListCoordinator/Sources/DefaultFriendListCoordinator.swift
@@ -32,8 +32,17 @@ public final class DefaultFriendListCoordinator: FriendListCoordinator {
         self.navigationController = navigationController
     }
     
+    public func start(storyFeedsStream: BehaviorRelay<[StoryFeedEntity]>) {
+        coordinate(by: .showFirendList(storyFeedsStream: storyFeedsStream))
+    }
+    
+    // TODO: start 메소드를 Coordinator 프로토콜에서 제외하는 것 고려해보기
     public func start() {
-        coordinate(by: .showFirendList)
+        Logger.log(
+            message: "FriendListCoordinator의 start 메소드는 구현되지 않음. start(storyFeedsStream:) 메소드를 사용할 것",
+            category: .default,
+            type: .default
+        )
     }
     
     public func coordinate(by coordinateAction: FriendListCoordinateAction) {
@@ -41,8 +50,8 @@ public final class DefaultFriendListCoordinator: FriendListCoordinator {
             switch coordinateAction {
             case .showFriendsStoolLog(let friendEntity):
                 self?.showFriendStoolLogViewController(of: friendEntity)
-            case .showFirendList:
-                self?.showFriendListViewController()
+            case .showFirendList(let storyFeedsStream):
+                self?.showFriendListViewController(storyFeedsStream: storyFeedsStream)
             case .showFriendInvitation(let toastMessageStream, let friendListUpdateStream):
                 self?.showFriendInvitationView(
                     toastMessageStream: toastMessageStream,
@@ -66,8 +75,8 @@ public final class DefaultFriendListCoordinator: FriendListCoordinator {
 }
 
 private extension DefaultFriendListCoordinator {
-    func showFriendListViewController() {
-        let viewModel = FriendListViewModel(coordinator: self)
+    func showFriendListViewController(storyFeedsStream: BehaviorRelay<[StoryFeedEntity]>) {
+        let viewModel = FriendListViewModel(coordinator: self, storyFeedsStream: storyFeedsStream)
         let viewController = FriendListViewController()
         viewController.bind(viewModel: viewModel)
         navigationController.pushViewController(viewController, animated: true)

--- a/Projects/Features/FeatureFriendList/FeatureFriendListCoordinatorInterface/Sources/FriendListCoordinateAction.swift
+++ b/Projects/Features/FeatureFriendList/FeatureFriendListCoordinatorInterface/Sources/FriendListCoordinateAction.swift
@@ -17,7 +17,7 @@ import Utils
 
 public enum FriendListCoordinateAction {
     case showFriendsStoolLog(friendEntity: FriendEntity)
-    case showFirendList
+    case showFirendList(storyFeedsStream: BehaviorRelay<[StoryFeedEntity]>)
     case showFriendInvitation(
         toastMessageStream: PublishRelay<ToastMessage>,
         friendListUpdateStream: PublishRelay<Void>

--- a/Projects/Features/FeatureFriendList/FeatureFriendListPresentation/Sources/FriendListViewController/FriendListViewModel.swift
+++ b/Projects/Features/FeatureFriendList/FeatureFriendListPresentation/Sources/FriendListViewController/FriendListViewModel.swift
@@ -36,19 +36,21 @@ public final class FriendListViewModel: ViewModelType {
     
     public struct State {
         let friendList = BehaviorRelay<[FriendEntity]>(value: [])
+        let storyFeeds: BehaviorRelay<[StoryFeedEntity]>
     }
     
     public let input = Input()
     public let output = Output()
-    public let state = State()
+    public let state: State
     
     @Inject(FriendListDIContainer.shared) private var friendListUseCase: FriendListUseCase
     
     private weak var coordinator: FriendListCoordinator?
     private var disposeBag = DisposeBag()
     
-    public init(coordinator: FriendListCoordinator?) {
+    public init(coordinator: FriendListCoordinator?, storyFeedsStream: BehaviorRelay<[StoryFeedEntity]>) {
         self.coordinator = coordinator
+        self.state = State(storyFeeds: storyFeedsStream)
         bind(coordinator: coordinator)
     }
     

--- a/Projects/Features/FeatureFriendList/FeatureFriendListPresentation/Sources/FriendListViewController/FriendListViewModel.swift
+++ b/Projects/Features/FeatureFriendList/FeatureFriendListPresentation/Sources/FriendListViewController/FriendListViewModel.swift
@@ -118,6 +118,24 @@ public final class FriendListViewModel: ViewModelType {
             }
             .disposed(by: disposeBag)
         
+        let fetchedStories = input.addingFriendDidComplete
+            .withUnretained(self)
+            .flatMapMaterialized { `self`, _ in
+                self.friendListUseCase.fetchStoryFeeds()
+            }
+            .share()
+        
+        fetchedStories
+            .compactMap { $0.element }
+            .bind(to: state.storyFeeds)
+            .disposed(by: disposeBag)
+        
+        fetchedStories
+            .compactMap { $0.error }
+            .map { _ in ToastMessage.story(.fetchStoryFeedFail) }
+            .bind(to: output.showToastMessge)
+            .disposed(by: disposeBag)
+        
         state.friendList
             .filter { !$0.isEmpty }
             .bind(to: output.showFriendList)

--- a/Projects/Features/FeatureFriendList/FeatureFriendListUseCase/Sources/DefaultFriendListUseCase.swift
+++ b/Projects/Features/FeatureFriendList/FeatureFriendListUseCase/Sources/DefaultFriendListUseCase.swift
@@ -21,6 +21,7 @@ public final class DefaultFriendListUseCase: FriendListUseCase {
     
     @Inject(SharedDIContainer.shared) private var userInfoUseCase: UserInfoUseCase
     @Inject(FriendListDIContainer.shared) private var friendListRepository: FriendListRepository
+    @Inject(SharedDIContainer.shared) private var storyFeedUseCase: StoryFeedUseCase
     
     public init() { }
     
@@ -88,6 +89,10 @@ public final class DefaultFriendListUseCase: FriendListUseCase {
                 return .invalidLength
             }
         }
+    }
+    
+    public func fetchStoryFeeds() -> Observable<[StoryFeedEntity]> {
+        return storyFeedUseCase.fetchStoryFeeds()
     }
 }
 

--- a/Projects/Features/FeatureFriendList/FeatureFriendListUseCase/Sources/Interface/FriendListUseCase.swift
+++ b/Projects/Features/FeatureFriendList/FeatureFriendListUseCase/Sources/Interface/FriendListUseCase.swift
@@ -24,4 +24,5 @@ public protocol FriendListUseCase {
     func fetchFriendList() -> Observable<[FriendEntity]>
     func requestAddingFriend(with invitationCode: String) -> Observable<Bool>
     func checkInvitationCodeValidation(_ invitationCode: String) -> Observable<InvitationCodeInputStatus>
+    func fetchStoryFeeds() -> Observable<[StoryFeedEntity]>
 }

--- a/Projects/Features/FeatureHome/FeatureHomeCoordinator/Sources/DefaultHomeCoordinator.swift
+++ b/Projects/Features/FeatureHome/FeatureHomeCoordinator/Sources/DefaultHomeCoordinator.swift
@@ -51,8 +51,8 @@ public final class DefaultHomeCoordinator: HomeCoordinator {
                 self?.pushHomeViewController(animated: animated)
             case .flowDidFinish:
                 self?.flowCompletionDelegate?.finishFlow()
-            case .cheeringButtonDidTap:
-                self?.startFriendListCoordinatorFlow()
+            case .cheeringButtonDidTap(let storyFeedsStream):
+                self?.startFriendListCoordinatorFlow(storyFeedsStream: storyFeedsStream)
             case .stoolLogButtonDidTap(let stoolLogsRelay):
                 self?.startStoolLogCoordinatorFlow(stoolLogsRelay: stoolLogsRelay)
             case .settingButtonDidTap:
@@ -140,10 +140,10 @@ private extension DefaultHomeCoordinator {
         navigationController.pushViewController(viewController, animated: true)
     }
     
-    func startFriendListCoordinatorFlow() {
+    func startFriendListCoordinatorFlow(storyFeedsStream: BehaviorRelay<[StoryFeedEntity]>) {
         let friendListCoordinator = DefaultFriendListCoordinator(navigationController: navigationController)
         add(childCoordinator: friendListCoordinator)
-        friendListCoordinator.start()
+        friendListCoordinator.start(storyFeedsStream: storyFeedsStream)
     }
 }
 

--- a/Projects/Features/FeatureHome/FeatureHomeCoordinatorInterface/Sources/HomeCoordinatorAction.swift
+++ b/Projects/Features/FeatureHome/FeatureHomeCoordinatorInterface/Sources/HomeCoordinatorAction.swift
@@ -15,7 +15,7 @@ import CoreEntity
 public enum HomeCoordinateAction {
     case flowDidStart(animated: Bool)
     case flowDidFinish
-    case cheeringButtonDidTap
+    case cheeringButtonDidTap(storyFeedsStream: BehaviorRelay<[StoryFeedEntity]>)
     case stoolLogButtonDidTap(stoolLogsRelay: BehaviorRelay<[StoolLogEntity]>)
     case settingButtonDidTap
     case reportButtonDidTap

--- a/Projects/Features/FeatureHome/FeatureHomePresentation/Sources/HomeViewController.swift
+++ b/Projects/Features/FeatureHome/FeatureHomePresentation/Sources/HomeViewController.swift
@@ -101,6 +101,10 @@ public final class HomeViewController: LifePoopViewController, ViewType {
             .bind(to: input.viewDidLoad)
             .disposed(by: disposeBag)
         
+        rx.viewWillAppear
+            .bind(to: input.viewWillAppear)
+            .disposed(by: disposeBag)
+        
         stoolLogRefreshControl.rx.controlEvent(.valueChanged)
             .bind(to: input.viewDidRefresh)
             .disposed(by: disposeBag)

--- a/Projects/Features/FeatureHome/FeatureHomePresentation/Sources/HomeViewModel.swift
+++ b/Projects/Features/FeatureHome/FeatureHomePresentation/Sources/HomeViewModel.swift
@@ -22,6 +22,7 @@ public final class HomeViewModel: ViewModelType {
     
     public struct Input {
         let viewDidLoad = PublishRelay<Void>()
+        let viewWillAppear = PublishRelay<Void>()
         let viewDidRefresh = PublishRelay<Void>()
         let settingButtonDidTap = PublishRelay<Void>()
         let reportButtonDidTap = PublishRelay<Void>()
@@ -220,6 +221,10 @@ public final class HomeViewModel: ViewModelType {
 
 private extension HomeViewModel {
     func bind(stoolLogHeaderViewModel: StoolLogHeaderViewModel) {
+        input.viewWillAppear
+            .bind(to: stoolLogHeaderViewModel.input.viewWillAppear)
+            .disposed(by: disposeBag)
+        
         input.viewDidRefresh
             .bind(to: stoolLogHeaderViewModel.input.viewDidRefresh)
             .disposed(by: disposeBag)

--- a/Projects/Features/FeatureHome/FeatureHomePresentation/Sources/StoolLogCollectionView/StoolLogHeaderViewModel.swift
+++ b/Projects/Features/FeatureHome/FeatureHomePresentation/Sources/StoolLogCollectionView/StoolLogHeaderViewModel.swift
@@ -23,6 +23,7 @@ public final class StoolLogHeaderViewModel: ViewModelType {
     public struct Input {
         let viewDidRefresh = PublishRelay<Void>()
         let viewDidLoad = PublishRelay<Void>()
+        let viewWillAppear = PublishRelay<Void>()
         let viewDidFinishLayoutSubviews = PublishRelay<Void>()
         let inviteFriendButtonDidTap = PublishRelay<Void>()
         let cheeringButtonDidTap = PublishRelay<Void>()
@@ -60,38 +61,39 @@ public final class StoolLogHeaderViewModel: ViewModelType {
     public init(coordinator: HomeCoordinator?) {
         self.coordinator = coordinator
         
-        let viewDidLoadOrRefresh = Observable.merge(
+        let viewDidLoadOrRefreshOrWillAppear = Observable.merge(
             input.viewDidLoad.asObservable(),
-            input.viewDidRefresh.asObservable()
+            input.viewDidRefresh.asObservable(),
+            input.viewWillAppear.asObservable()
         )
         .share()
         
-        viewDidLoadOrRefresh
+        viewDidLoadOrRefreshOrWillAppear
             .withLatestFrom(state.storyFeeds)
             .compactMap { $0 }
             .bind(to: output.updateStoryFeeds)
             .disposed(by: disposeBag)
         
-        viewDidLoadOrRefresh
+        viewDidLoadOrRefreshOrWillAppear
             .compactMap { Date().koreanDateString }
             .map { LocalizableString.stoolDiaryFor($0) }
             .bind(to: output.setDateDescription)
             .disposed(by: disposeBag)
         
-        viewDidLoadOrRefresh
+        viewDidLoadOrRefreshOrWillAppear
             .withLatestFrom(state.storyFeeds)
             .map { $0.isEmpty }
             .bind(to: output.isStoryFeedEmpty)
             .disposed(by: disposeBag)
         
-        viewDidLoadOrRefresh
+        viewDidLoadOrRefreshOrWillAppear
             .withLatestFrom(state.friends)
             .filter { $0.isEmpty }
             .map { _ in }
             .bind(to: output.showInviteFriendUI)
             .disposed(by: disposeBag)
         
-        viewDidLoadOrRefresh
+        viewDidLoadOrRefreshOrWillAppear
             .withLatestFrom(state.cheeringInfo)
             .compactMap { $0 }
             .filter { $0.count > .zero }
@@ -99,7 +101,7 @@ public final class StoolLogHeaderViewModel: ViewModelType {
             .bind(to: output.updateCheeringProfileCharacters)
             .disposed(by: disposeBag)
         
-        viewDidLoadOrRefresh
+        viewDidLoadOrRefreshOrWillAppear
             .withLatestFrom(state.cheeringInfo)
             .compactMap { $0 }
             .filter { $0.count > .zero }
@@ -107,7 +109,7 @@ public final class StoolLogHeaderViewModel: ViewModelType {
             .bind(to: output.updateCheeringFriendNameAndCount)
             .disposed(by: disposeBag)
         
-        viewDidLoadOrRefresh
+        viewDidLoadOrRefreshOrWillAppear
             .withUnretained(self)
             .filter { `self`, _ in
                 !self.state.friends.value.isEmpty

--- a/Projects/Features/FeatureHome/FeatureHomePresentation/Sources/StoolLogCollectionView/StoolLogHeaderViewModel.swift
+++ b/Projects/Features/FeatureHome/FeatureHomePresentation/Sources/StoolLogCollectionView/StoolLogHeaderViewModel.swift
@@ -138,7 +138,10 @@ public final class StoolLogHeaderViewModel: ViewModelType {
             input.inviteFriendButtonDidTap.asObservable(),
             input.cheeringButtonDidTap.asObservable()
         )
-        .bind { coordinator?.coordinate(by: .cheeringButtonDidTap) }
+        .withUnretained(self)
+        .bind { `self`, _ in
+            coordinator?.coordinate(by: .cheeringButtonDidTap(storyFeedsStream: self.state.storyFeeds))
+        }
         .disposed(by: disposeBag)
     
         NotificationCenter.default.rx.notification(.updateCheering)

--- a/Projects/Utils/Resources/Localizable.strings
+++ b/Projects/Utils/Resources/Localizable.strings
@@ -168,6 +168,8 @@
 "toastFetchFriendListFail" = "친구 목록을 불러오는 데 실패했습니다.";
 "toastFetchStoolLogSuccess" = "변 기록을 성공적으로 불러왔습니다.";
 "toastFetchStoolLogFail" = "변 기록을 불러오는 데 실패했습니다.";
+"toastFetchStoryFeedSuccess" = "스토리 피드를 성공적으로 불러왔습니다.";
+"toastFetchStoryFeedFail" = "스토리 피드를 불러오는 데 실패했습니다.";
 
 "toastFetchCheeringInfoSuccess" = "응원 정보를 성공적으로 불러왔습니다.";
 "toastFetchCheeringInfoFail" = "응원 정보를 불러오는 데 실패했습니다.";

--- a/Projects/Utils/Sources/Enum/ToastMessage+kind.swift
+++ b/Projects/Utils/Sources/Enum/ToastMessage+kind.swift
@@ -87,6 +87,13 @@ public extension ToastMessage {
             case .addingFriendFail:
                 return .failure
             }
+        case .story(let story):
+            switch story {
+            case .fetchStoryFeedFail:
+                return .failure
+            case .fetchStoryFeedSuccess:
+                return .success
+            }
         }
     }
 }

--- a/Projects/Utils/Sources/Enum/ToastMessage.swift
+++ b/Projects/Utils/Sources/Enum/ToastMessage.swift
@@ -15,6 +15,7 @@ public enum ToastMessage {
     case stoolLog(StoolLog)
     case setting(Setting)
     case invitation(Invitation)
+    case story(Story)
     
     public var localized: String {
         switch self {
@@ -87,6 +88,13 @@ public enum ToastMessage {
                 return LocalizableString.toastAddingFriendSuccess
             case .addingFriendFail(let reason):
                 return reason.localized
+            }
+        case .story(let story):
+            switch story {
+            case .fetchStoryFeedFail:
+                return LocalizableString.toastFetchStoryFeedFail
+            case .fetchStoryFeedSuccess:
+                return LocalizableString.toastFetchStoryFeedSuccess
             }
         }
     }
@@ -162,5 +170,12 @@ public extension ToastMessage {
                 }
             }
         }
+    }
+}
+
+public extension ToastMessage {
+    enum Story {
+        case fetchStoryFeedFail
+        case fetchStoryFeedSuccess
     }
 }


### PR DESCRIPTION
### 🔖 관련 이슈
- #165 

<br> 

### ⚒️ 작업 내역

- [x] 친구 추가 API에 대한 정상 응답 받았을 시, 스토리 API 호출하여 홈 화면의 State에 바인딩
- [x] viewWillAppear될 때 마다 state에 있는 storyFeeds 값을 받도록 수정 

<br>

### 💻 리뷰어 가이드

새로운 친구를 추가한 이후 홈 화면으로 돌아갔을 때,  
별도의 리프레시 없이도 해당 친구에 대한 스토리가 홈 화면 상단에 나타나면 됩니다.

<br>

### 📝 부가 설명

친구 추가 요청에 대한 응답이 정상일 경우, 연이어서 친구의 스토리를 요청하여 state에 전달합니다.  
이후 홈 화면이 viewWillAppear 될 때 마다 state에 있는 스토리 피드값을 받도록 수정했습니다.

<br> 

### 📑 첨부 자료

https://github.com/LifePoop/LifePoop_iOS/assets/57667738/ee8dbd7d-ff19-459e-b186-75453250ff94
