### PR TITLE
의견 보내기 URL을 사파리 앱에서 열도록 변경

### DIFF
--- a/Projects/DesignSystem/Sources/Component/UIViewController/LifePoopWebViewController.swift
+++ b/Projects/DesignSystem/Sources/Component/UIViewController/LifePoopWebViewController.swift
@@ -9,6 +9,7 @@
 import UIKit
 import WebKit
 
+@available(*, deprecated, message: "피드백 URL이 Safari에서 열리도록 변경되어 더 이상 사용하지 않음")
 public final class LifePoopWebViewController: UIViewController {
     
     private var webView: WKWebView?

--- a/Projects/Features/FeatureSetting/FeatureSettingCoordinator/Sources/DefaultSettingCoordinator.swift
+++ b/Projects/Features/FeatureSetting/FeatureSettingCoordinator/Sources/DefaultSettingCoordinator.swift
@@ -105,8 +105,7 @@ private extension DefaultSettingCoordinator {
     
     func pushFeedbackViewController() {
         guard let feedbackURL = URL(string: Constant.LifePoopURL.feedback) else { return }
-        let feedbackWebViewController = LifePoopWebViewController(targetURL: feedbackURL)
-        navigationController.pushViewController(feedbackWebViewController, animated: true)
+        UIApplication.shared.open(feedbackURL)
     }
 }
 


### PR DESCRIPTION
### 🔖 관련 이슈
- #166 

<br> 

### ⚒️ 작업 내역

- [x] 의견 보내기 화면을 webView -> Safari URL로 열리도록 변경
