### PR TITLE
초대 코드 입력 관련 UI 수정

### DIFF
--- a/Projects/Features/FeatureFriendList/FeatureFriendListPresentation/Sources/FriendListViewController/FriendListViewController.swift
+++ b/Projects/Features/FeatureFriendList/FeatureFriendListPresentation/Sources/FriendListViewController/FriendListViewController.swift
@@ -115,7 +115,7 @@ public final class FriendListViewController: LifePoopViewController, ViewType {
                 let fullString = NSMutableAttributedString()
                 
                 let imageAttachment = NSTextAttachment()
-                imageAttachment.image = UIImage(systemName: "checkmark.circle.fill")?
+                imageAttachment.image = UIImage(systemName: message.systemImageName)?
                                             .withTintColor(ColorAsset.white.color)
                 fullString.append(NSAttributedString(attachment: imageAttachment))
             

--- a/Projects/Features/FeatureFriendList/FeatureFriendListPresentation/Sources/InvitationCodeViewController/InvitationCodeViewController.swift
+++ b/Projects/Features/FeatureFriendList/FeatureFriendListPresentation/Sources/InvitationCodeViewController/InvitationCodeViewController.swift
@@ -75,7 +75,7 @@ public final class InvitationCodeViewController: LifePoopViewController, ViewTyp
             .disposed(by: disposeBag)
         
         output.enableConfirmButton
-            .asSignal()
+            .asSignal(onErrorJustReturn: false)
             .emit(to: textFieldAlertView.rx.isConfirmButtonEnabled)
             .disposed(by: disposeBag)
         

--- a/Projects/Features/FeatureFriendList/FeatureFriendListPresentation/Sources/InvitationCodeViewController/InvitationCodeViewModel.swift
+++ b/Projects/Features/FeatureFriendList/FeatureFriendListPresentation/Sources/InvitationCodeViewController/InvitationCodeViewModel.swift
@@ -85,7 +85,7 @@ public final class InvitationCodeViewModel: ViewModelType {
         let dismissAlertView = PublishRelay<Void>()
         let showInvitationCodePopup = PublishRelay<Void>()
         let showSharingActivityView = PublishRelay<Void>()
-        let enableConfirmButton = PublishRelay<Bool>()
+        let enableConfirmButton = BehaviorRelay<Bool>(value: false)
         let hideWarningLabel = PublishRelay<Bool>()
         let warningLabelText = BehaviorRelay<String>(value: "")
     }

--- a/Projects/Utils/Sources/Enum/ToastMessage.swift
+++ b/Projects/Utils/Sources/Enum/ToastMessage.swift
@@ -98,6 +98,20 @@ public enum ToastMessage {
             }
         }
     }
+    
+    public var systemImageName: String {
+        switch self {
+        case .invitation(let invitation):
+            switch invitation {
+            case .invitationCodeCopySuccess, .invitationCodeSharingSuccess, .addingFriendSuccess:
+                return  "checkmark.circle.fill"
+            case .invitationCodeCopyFail, .invitationCodeSharingFail, .addingFriendFail:
+                return  "exclamationmark.circle.fill"
+            }
+        default:
+            return "checkmark.circle.fill"
+        }
+    }
 }
 
 public extension ToastMessage {


### PR DESCRIPTION
### 🔖 관련 이슈
- #171 

<br> 

### ⚒️ 작업 내역

- [x] 초대코드 입력 팝업 띄웠을 때  확인 버튼 비활성화
- [x] 실패 토스트 노출될 때 이미지 체크가 아닌 느낌표로 표시

<br>

### 💻 리뷰어 가이드
> 리뷰어가 작업을 확인할 수 있는 방법, 기대되는 정상적인 동작 내용을 작성

- 엄청 단순 작업이라.. 코드만 보셔도 되긴 합니다 ㅋㅋ
- 초대코드 입력 창 최초로 띄웠을 때 확인 버튼 비활성화되면 됩니다.
- 유효하지 않은 초대코드 아무거나 입력 후 확인 누르고, 토스트 메시지에 느낌표 노출되는 것 확인하면 됩니다.