### PR TITLE
회원가입 처리 수정

### DIFF
--- a/Projects/Core/CoreEntity/Sources/AgreementCondition.swift
+++ b/Projects/Core/CoreEntity/Sources/AgreementCondition.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct AgreementCondition {
+public struct AgreementCondition: CustomStringConvertible {
     
     public enum DescriptionTextSize {
         case large
@@ -33,6 +33,10 @@ public struct AgreementCondition {
     public let descriptionTextSize: DescriptionTextSize
     public let containsDetailView: Bool
     public let selectionType: SelectionType
+    
+    public var description: String {
+        descriptionText
+    }
     
     public init(
         descriptionText: String,

--- a/Projects/Core/CoreEntity/Sources/SignupInput.swift
+++ b/Projects/Core/CoreEntity/Sources/SignupInput.swift
@@ -11,16 +11,16 @@ import Foundation
 public struct SignupInput {
     
     public let nickname: String
-    public let birthDate: String
-    public let gender: GenderType
+    public let birthDate: String?
+    public let gender: GenderType?
     public let conditions: Set<AgreementCondition>
     public let oAuthAccessToken: String
     public let provider: LoginType
     
     public init(
         nickname: String,
-        birthDate: String,
-        gender: GenderType,
+        birthDate: String?,
+        gender: GenderType?,
         conditions: Set<AgreementCondition>,
         oAuthAccessToken: String,
         provider: LoginType

--- a/Projects/Core/CoreEntity/Sources/SignupInput.swift
+++ b/Projects/Core/CoreEntity/Sources/SignupInput.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct SignupInput {
+public struct SignupInput: CustomStringConvertible {
     
     public let nickname: String
     public let birthDate: String?
@@ -16,6 +16,15 @@ public struct SignupInput {
     public let conditions: Set<AgreementCondition>
     public let oAuthAccessToken: String
     public let provider: LoginType
+    
+    public var description: String {
+        """
+        nickname: \(nickname)
+        gender: \(gender?.description ?? "nil")
+        conditions: \(conditions)
+        loginType: \(provider.description)
+        """
+    }
     
     public init(
         nickname: String,

--- a/Projects/DesignSystem/Sources/Component/ConditionalTextField/ConditionalTextField.swift
+++ b/Projects/DesignSystem/Sources/Component/ConditionalTextField/ConditionalTextField.swift
@@ -23,7 +23,7 @@ final public class ConditionalTextField: UIControl {
     private let essentialMark: UILabel = {
         let label = UILabel()
         label.font = UIFont.systemFont(ofSize: 20, weight: .bold)
-        label.textColor = ColorAsset.pooPink.color
+        label.textColor = ColorAsset.primary.color
         label.text = "*"
         label.sizeToFit()
         label.isHidden = true

--- a/Projects/DesignSystem/Sources/Component/ConditionalTextField/ConditionalTextField.swift
+++ b/Projects/DesignSystem/Sources/Component/ConditionalTextField/ConditionalTextField.swift
@@ -20,6 +20,16 @@ final public class ConditionalTextField: UIControl {
         return label
     }()
     
+    private let essentialMark: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.systemFont(ofSize: 20, weight: .bold)
+        label.textColor = ColorAsset.pooPink.color
+        label.text = "*"
+        label.sizeToFit()
+        label.isHidden = true
+        return label
+    }()
+    
     private lazy var textField: UITextField = {
         let textField = UITextField()
         textField.addTarget(self, action: #selector(textFieldDidChange), for: .editingChanged)
@@ -105,6 +115,12 @@ final public class ConditionalTextField: UIControl {
         }
     }
     
+    public var markAsEssential: Bool = false {
+        didSet {
+            essentialMark.isHidden = !markAsEssential
+        }
+    }
+    
     public override var intrinsicContentSize: CGSize {
         let sumOfSubViewsHeight = self.subviews.reduce(0) { $0 + $1.bounds.height }
         let sumOfMargins: CGFloat = 42
@@ -140,6 +156,7 @@ final public class ConditionalTextField: UIControl {
     private func configureUI() {
         
         addSubview(titleLabel)
+        addSubview(essentialMark)
         addSubview(textField)
         addSubview(separatorView)
         addSubview(subLabel)
@@ -147,6 +164,11 @@ final public class ConditionalTextField: UIControl {
         titleLabel.snp.makeConstraints { make in
             make.top.equalToSuperview()
             make.leading.equalToSuperview()
+        }
+        
+        essentialMark.snp.makeConstraints { make in
+            make.top.equalToSuperview()
+            make.leading.equalTo(titleLabel.snp.trailing)
         }
         
         textField.snp.makeConstraints { make in

--- a/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/SignupScene/ConditionSelectionCell/ConditionSelectionView.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/SignupScene/ConditionSelectionCell/ConditionSelectionView.swift
@@ -41,7 +41,7 @@ final class ConditionSelectionView: UIControl {
     private let essentialMark: UILabel = {
         let label = UILabel()
         label.font = UIFont.systemFont(ofSize: 20, weight: .bold)
-        label.textColor = ColorAsset.pooPink.color
+        label.textColor = ColorAsset.primary.color
         label.text = "*"
         label.sizeToFit()
         label.isHidden = true

--- a/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/SignupScene/ConditionSelectionCell/ConditionSelectionView.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/SignupScene/ConditionSelectionCell/ConditionSelectionView.swift
@@ -38,6 +38,16 @@ final class ConditionSelectionView: UIControl {
         return label
     }()
     
+    private let essentialMark: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.systemFont(ofSize: 20, weight: .bold)
+        label.textColor = ColorAsset.pooPink.color
+        label.text = "*"
+        label.sizeToFit()
+        label.isHidden = true
+        return label
+    }()
+    
     var isChecked: Bool = false {
         didSet {
             let image = isChecked ? selectedCheckBoxImage : deselectedCheckBoxImage
@@ -48,6 +58,12 @@ final class ConditionSelectionView: UIControl {
     var descriptionText: String = "" {
         didSet {
             descriptionLabel.text = descriptionText
+        }
+    }
+    
+    public var markAsEssential: Bool = false {
+        didSet {
+            essentialMark.isHidden = !markAsEssential
         }
     }
 
@@ -80,6 +96,7 @@ final class ConditionSelectionView: UIControl {
         
         addSubview(checkBoxImageView)
         addSubview(descriptionLabel)
+        addSubview(essentialMark)
                 
         checkBoxImageView.snp.makeConstraints { make in
             make.leading.equalToSuperview()
@@ -89,6 +106,11 @@ final class ConditionSelectionView: UIControl {
         descriptionLabel.snp.makeConstraints { make in
             make.leading.equalTo(checkBoxImageView.snp.trailing).offset(16)
             make.centerY.equalToSuperview()
+        }
+        
+        essentialMark.snp.makeConstraints { make in
+            make.top.equalTo(descriptionLabel.snp.top)
+            make.leading.equalTo(descriptionLabel.snp.trailing)
         }
     }
     

--- a/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/SignupScene/SignupViewController.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/SignupScene/SignupViewController.swift
@@ -229,6 +229,17 @@ public final class SignupViewController: LifePoopViewController, ViewType {
                 self.selectAllConditionView.configure(with: entity)
             })
             .disposed(by: disposeBag)
+        
+        output.showError
+            .observe(on: MainScheduler.asyncInstance)
+            .withUnretained(self)
+            .bind(onNext: { `self`, error in
+                self.showSystemAlert(
+                    title: "Signup Error",
+                    message: error.localizedDescription
+                )
+            })
+            .disposed(by: disposeBag)
     }
     
     public override func configureUI() {

--- a/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/SignupScene/SignupViewController.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/SignupScene/SignupViewController.swift
@@ -33,6 +33,7 @@ public final class SignupViewController: LifePoopViewController, ViewType {
         let textField = ConditionalTextField()
         textField.title = LocalizableString.pleaseSetNickname
         textField.placeholder = LocalizableString.nicknamePlaceholder
+        textField.markAsEssential = true
         return textField
     }()
     
@@ -73,7 +74,11 @@ public final class SignupViewController: LifePoopViewController, ViewType {
         return stackView
     }()
     
-    private let selectAllConditionView: ConditionSelectionView = ConditionSelectionView()
+    private let selectAllConditionView: ConditionSelectionView = {
+        let view = ConditionSelectionView()
+        view.markAsEssential = true
+        return view
+    }()
     
     private let conditionSelectionCollectionViewDelegate = ConditionSelectionCollectionViewDelegate()
     private lazy var conditionSelectionCollectionView: UICollectionView = {

--- a/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/SignupScene/SignupViewModel.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/SignupScene/SignupViewModel.swift
@@ -62,6 +62,8 @@ public final class SignupViewModel: ViewModelType {
     
     public struct State {
         let selectedConditions = BehaviorRelay<Set<AgreementCondition>>(value: [])
+        let gender = BehaviorRelay<GenderType?>(value: nil)
+        let birthDate = BehaviorRelay<String?>(value: nil)
     }
     
     public let input = Input()
@@ -125,14 +127,17 @@ public final class SignupViewModel: ViewModelType {
             .bind(to: output.nicknameTextFieldStatus)
             .disposed(by: disposeBag)
         
-        let birthdayInputStatus = input.didEnterBirthDate
+        let birthDateInput = input.didEnterBirthDate.share()
+        
+        birthDateInput
+            .bind(to: state.birthDate)
+            .disposed(by: disposeBag)
+        
+        birthDateInput
             .withUnretained(self)
             .flatMap { `self`, input in
                 self.signupUseCase.isBirthdayInputValid(input)
             }
-            .share()
-  
-        birthdayInputStatus
             .map { $0.status }
             .bind(to: output.birthdayTextFieldStatus)
             .disposed(by: disposeBag)
@@ -150,9 +155,16 @@ public final class SignupViewModel: ViewModelType {
             })
             .disposed(by: disposeBag)
         
-        input.didTapGenderButton
+        let genderInput = input.didTapGenderButton
             .map { GenderType.allCases[$0] }
+            .share()
+        
+        genderInput
             .bind(to: output.selectGender)
+            .disposed(by: disposeBag)
+        
+        genderInput
+            .bind(to: state.gender)
             .disposed(by: disposeBag)
 
         input.didTapLeftBarbutton
@@ -164,11 +176,11 @@ public final class SignupViewModel: ViewModelType {
         let signupInput = Observable
             .combineLatest(
                 input.didEnterNickname,
-                input.didEnterBirthDate,
-                output.selectGender,
+                state.birthDate,
+                state.gender,
                 state.selectedConditions
             )
-            .map {(nickname: $0, birthDate: $1, gender: $2, conditions: $3)}
+            .map { (nickname: $0, birthDate: $1, gender: $2, conditions: $3) }
             .share()
         
         signupInput
@@ -176,20 +188,20 @@ public final class SignupViewModel: ViewModelType {
             .flatMap { `self`, signupInfo in
                 Observable.combineLatest(
                     self.signupUseCase.isNicknameInputValid(signupInfo.nickname).map { $0.isValid },
-                    self.signupUseCase.isBirthdayInputValid(signupInfo.birthDate).map { $0.isValid },
                     self.signupUseCase.isAllEsssentialConditionsSelected(signupInfo.conditions)
                 )
             }
-            .map { $0 && $1 && $2 }
+            .map { $0 && $1 }
             .bind(to: output.activateNextButton)
             .disposed(by: disposeBag)
         
-        input.didTapNextButton
+        let requestSignup = input.didTapNextButton
             .withLatestFrom(signupInput)
             .compactMap { [weak self] nickname, birthDate, gender, conditions -> SignupInput? in
                 guard let oAuthAccessToekn = self?.authInfo.accessToken,
-                      let provider = self?.authInfo.loginType,
-                      let birthDate = self?.signupUseCase.createFormattedDateString(with: birthDate) else { return nil }
+                      let provider = self?.authInfo.loginType else { return nil }
+                
+                let birthDate = self?.signupUseCase.createFormattedDateString(with: birthDate)
 
                 return SignupInput(
                     nickname: nickname,

--- a/Projects/Features/FeatureLogin/FeatureLoginRepository/Sources/DefaultSignupRepository.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginRepository/Sources/DefaultSignupRepository.swift
@@ -22,15 +22,25 @@ public final class DefaultSignupRepository: NSObject, SignupRepository {
     public override init() { }
     
     public func requestSignup(with signupInput: SignupInput) -> Single<UserAuthInfoEntity> {
-        urlSessionEndpointService
+        
+        var requestBody: [String: String] = [
+            "nickname": signupInput.nickname,
+            "oAuthAccessToken": signupInput.oAuthAccessToken
+        ]
+        
+        if let birthDate = signupInput.birthDate,
+           birthDate.count > 0 {
+            requestBody["birth"] = birthDate
+        }
+        
+        if let gender = signupInput.gender {
+            requestBody["sex"] = gender.description
+        }
+
+        return urlSessionEndpointService
             .fetchNetworkResult(
                 endpoint: LifePoopLocalTarget.signup(provider: signupInput.provider.description),
-                with: [
-                    "nickname": signupInput.nickname,
-                    "birth": signupInput.birthDate,
-                    "sex": signupInput.gender.description,
-                    "oAuthAccessToken": signupInput.oAuthAccessToken
-                ]
+                with: requestBody
             )
             .map { networkResult -> UserAuthInfoEntity in
                 let statusCode = networkResult.statusCode

--- a/Projects/Features/FeatureLogin/FeatureLoginRepository/Sources/DefaultSignupRepository.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginRepository/Sources/DefaultSignupRepository.swift
@@ -71,7 +71,11 @@ public final class DefaultSignupRepository: NSObject, SignupRepository {
             .logErrorIfDetected(category: .network, type: .error)
     }
 
-    private func createUserAuthInfo(accessToken: String?, refreshToken: String?, loginType: LoginType?) throws -> UserAuthInfoEntity {
+    private func createUserAuthInfo(
+        accessToken: String?,
+        refreshToken: String?,
+        loginType: LoginType?
+    ) throws -> UserAuthInfoEntity {
         guard let accessToken = accessToken,
               let refreshToken = refreshToken,
               let loginType = loginType else {

--- a/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/DefaultSignupUseCase.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/DefaultSignupUseCase.swift
@@ -116,7 +116,8 @@ public final class DefaultSignupUseCase: SignupUseCase {
     }
     
     // TODO: 추후에 Utils에 구현된 부분으로 대체 가능한 지 확인 후 제거
-    public func createFormattedDateString(with dateString: String) -> String? {
+    public func createFormattedDateString(with dateString: String?) -> String? {
+        guard let dateString = dateString else { return nil }
         
         let inputDateFormatter = DateFormatter()
         inputDateFormatter.dateFormat = "yyMMdd"

--- a/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/DefaultSignupUseCase.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/DefaultSignupUseCase.swift
@@ -32,18 +32,13 @@ public final class DefaultSignupUseCase: SignupUseCase {
     
     /** 사용자 입력 회원가입 정보로 서버에 새로운 회원정보 추가 요청 **/
     public func requestSignup(_ signupInfo: SignupInput) -> Observable<Bool> {
-        
+
         Logger.log(
-            message: """
-            회원 가입 요청
-            nickname: \(signupInfo.nickname)
-            gender: \(signupInfo.gender.description)
-            loginType: \(signupInfo.provider.description)
-            """,
+            message: "회원가입요청:\n\(signupInfo)",
             category: .authentication,
             type: .debug
         )
-        
+
         return signupRepository.requestSignup(with: signupInfo)
             .asObservable()
             .withUnretained(self)
@@ -57,7 +52,6 @@ public final class DefaultSignupUseCase: SignupUseCase {
                         )
                     })
             }
-            .catchAndReturn(false)
     }
     
     public func fetchSelectableConditions() -> Observable<[AgreementCondition]> {

--- a/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/Interface/SignupUseCase.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/Interface/SignupUseCase.swift
@@ -17,6 +17,6 @@ public protocol SignupUseCase {
     func fetchSelectableConditions() -> Observable<[AgreementCondition]>
     func isNicknameInputValid(_ input: String) -> Observable<NicknameTextInput>
     func isBirthdayInputValid(_ input: String) -> Observable<BirthdayTextInput>
-    func createFormattedDateString(with dateString: String) -> String?
+    func createFormattedDateString(with dateString: String?) -> String?
     func isAllEsssentialConditionsSelected(_ selectedConditions: Set<AgreementCondition>) -> Observable<Bool>
 }

--- a/Projects/Logger/Sources/Rx+log.swift
+++ b/Projects/Logger/Sources/Rx+log.swift
@@ -15,7 +15,7 @@ public extension ObservableType {
     func log(message: String, category: OSLog.LogCategory, printElement: Bool = false) -> Observable<Element> {
         return self.logErrorIfDetected(category: category, type: .error)
             .do(onNext: { element in
-            let meesage = printElement ? "\(message)\nvalue:\(element)" : message
+            let message = printElement ? "\(message)\nvalue:\(element)" : message
             Logger.log(message: message, category: category, type: .debug)
         })
     }


### PR DESCRIPTION
### 🔖 관련 이슈
- #176 

<br> 

### ⚒️ 작업 내역

- [x] 생년월일, 성별 선택 부분 옵셔널로 변경
- [x] 필수 항목 끝에 빨간 별표시 추가

<br>

### 💻 리뷰어 가이드

- 닉네임, 약관 동의 항목 2가지 조건만 충족되도 회원가입 버튼이 활성화되야 합니다.
- 회원가입 실패 시에 시스템 alert가 노출되야 합니다.
<br>

### 📝 부가 설명
- flatMapMaterialized 적용 안된 부분이 있어서 하는김에 수정했어요
- 회원가입 실패를 인지할 수 있도록 alert 띄우는 부분 추가했어요
- 급하게 수정하느라 좀 엉성하거나 이상한 부분이 있을 수 있는데, 이건 피드백 주시면 차차 수정해나갈께요!

<br> 

### 📑 첨부 자료
> 캡쳐 실수로;; 별표시가 안뜨네요 ㅋㅋ 기기에서는 정상적으로 확인 되실겁니다.
- 회원가입 실패, 성공 여부에 따라 아래처럼 나타납니다.
- 현재 서버쪽에 수정 반영 안된듯 한데.. key에 성별이랑 생년월일 부분 없으면 400 에러가 뜹니다.

|회원가입 실패|회원가입 성공|
|-----|-----|
|![Simulator Screen Recording - iPhone 12 mini - 2023-12-14 at 00 58 44](https://github.com/LifePoop/LifePoop_iOS/assets/68586291/e7eb61d7-777f-4d12-bb08-dcef536fab7b)|![Simulator Screen Recording - iPhone 12 mini - 2023-12-14 at 00 58 57](https://github.com/LifePoop/LifePoop_iOS/assets/68586291/e45d3fb4-cfa4-4fe2-8935-919cfae40641)|



