### PR TITLE
친구 초대 문구 수정

### DIFF
--- a/Projects/Features/FeatureFriendList/FeatureFriendListPresentation/Sources/InvitationCodeViewController/InvitationCodeViewController.swift
+++ b/Projects/Features/FeatureFriendList/FeatureFriendListPresentation/Sources/InvitationCodeViewController/InvitationCodeViewController.swift
@@ -39,6 +39,10 @@ public final class InvitationCodeViewController: LifePoopViewController, ViewTyp
     public func bindInput(to viewModel: InvitationCodeViewModel) {
         let input = viewModel.input
         
+        rx.viewDidLoad
+            .bind(to: input.viewDidLoad)
+            .disposed(by: disposeBag)
+        
         rx.viewDidAppear
             .bind(to: input.viewDidAppear)
             .disposed(by: disposeBag)
@@ -86,8 +90,8 @@ public final class InvitationCodeViewController: LifePoopViewController, ViewTyp
         
         output.showSharingActivityView
             .asSignal()
-            .emit(with: self, onNext: { `self`, _ in
-                self.showSharingPopup()
+            .emit(with: self, onNext: { `self`, invitationText in
+                self.showSharingPopup(with: invitationText)
             })
             .disposed(by: disposeBag)
         
@@ -120,12 +124,9 @@ private extension InvitationCodeViewController {
         }
     }
     
-    func showSharingPopup() {
-        guard let invitationCode = viewModel?.invitationCode,
-              !invitationCode.isEmpty else { return }
-        
+    func showSharingPopup(with invitationText: String) {
         let activityViewController = UIActivityViewController(
-            activityItems: [invitationCode],
+            activityItems: [invitationText],
             applicationActivities: nil
         )
         

--- a/Projects/Features/FeatureFriendList/FeatureFriendListUseCase/Sources/DefaultFriendListUseCase.swift
+++ b/Projects/Features/FeatureFriendList/FeatureFriendListUseCase/Sources/DefaultFriendListUseCase.swift
@@ -31,6 +31,11 @@ public final class DefaultFriendListUseCase: FriendListUseCase {
             .asObservable()
     }
     
+    public var userNickname: Observable<String> {
+        userInfoUseCase.userInfo
+            .map { $0?.nickname ?? "" }
+    }
+    
     public func fetchFriendList() -> Observable<[FriendEntity]> {
         userInfoUseCase.userInfo
             .compactMap { $0?.authInfo.accessToken }

--- a/Projects/Features/FeatureFriendList/FeatureFriendListUseCase/Sources/Interface/FriendListUseCase.swift
+++ b/Projects/Features/FeatureFriendList/FeatureFriendListUseCase/Sources/Interface/FriendListUseCase.swift
@@ -21,6 +21,7 @@ public enum InvitationError: Error {
 
 public protocol FriendListUseCase {
     var invitationCode: Observable<String> { get }
+    var userNickname: Observable<String> { get }
     func fetchFriendList() -> Observable<[FriendEntity]>
     func requestAddingFriend(with invitationCode: String) -> Observable<Bool>
     func checkInvitationCodeValidation(_ invitationCode: String) -> Observable<InvitationCodeInputStatus>

--- a/Projects/Utils/Resources/Localizable.strings
+++ b/Projects/Utils/Resources/Localizable.strings
@@ -87,6 +87,7 @@
 "doneEntering" = "입력 완료";
 "cannotEnterCodeOfSelf" = "자기 자신의 코드를 입력할 수 없습니다";
 "shouldEnterValidLengthOfCode" = "초대 코드 8자를 정확히 입력해주세요";
+"invitationText" = "\"나의 똥생연분인 너에게\"\n%@님께서 친구 초대 코드를 보냈어요!\n\n💌초대코드 : %@\n\n[라이푸 하는 방법]\n1. 라이푸 앱 다운로드\n2. 친구 초대 또는 친구 목록으로 이동\n3. (+)버튼을 누르고 초대코드 입력하면 끝!";
 
 /* 친구 목록 - 친구의 변 기록*/
 "stoolDiaryForFriend" = "%@님의 변 기록이에요";


### PR DESCRIPTION
### 🔖 관련 이슈
- #174 

<br> 

### ⚒️ 작업 내역

- [x] 친구 초대 코드를 공유할 때 나타낼 문구를 새로운 요구사항에 맞게 수정

<br>

### 📝 부가 설명

추후 앱스토어 링크와 바이럴 마케팅 링크도 포함될 예정입니다.

<br> 

### 📑 첨부 자료

|작업 이전|작업 이후|
|-----|-----|
|![image](https://github.com/LifePoop/LifePoop_iOS/assets/57667738/5ae46ca0-ea0c-472f-a562-602362d5cee2)|![image](https://github.com/LifePoop/LifePoop_iOS/assets/57667738/7e7be3c5-e255-4feb-82bb-746709ae083b)|




