### PR TITLE
변 횟수가 동일할 경우, 지정된 순서로 나타나도록 수정

### DIFF
--- a/Projects/DesignSystem/Sources/Component/UIView/EmptyStoolCharacterView.swift
+++ b/Projects/DesignSystem/Sources/Component/UIView/EmptyStoolCharacterView.swift
@@ -1,6 +1,6 @@
 //
-//  EmptyFriendListView.swift
-//  FeatureFriendListPresentation
+//  EmptyStoolCharacterView.swift
+//  DesignSystem
 //
 //  Created by Lee, Joon Woo on 2023/06/13.
 //  Copyright © 2023 Lifepoo. All rights reserved.
@@ -10,14 +10,12 @@ import UIKit
 
 import SnapKit
 
-import DesignSystem
 import Utils
 
-final class EmptyFriendListView: UIView {
+public final class EmptyStoolCharacterView: UIView {
     
     private let descriptionLabel: UILabel = {
         let label = UILabel()
-        label.text = LocalizableString.inviteFriendsAndEncourageBowelMovements
         label.numberOfLines = 0
         label.font = UIFont.systemFont(ofSize: 18, weight: .semibold)
         label.textColor = ColorAsset.gray600.color
@@ -27,8 +25,9 @@ final class EmptyFriendListView: UIView {
     
     private let characterImageView = UIImageView(image: ImageAsset.friendsEmptyStatus.original)
     
-    override init(frame: CGRect) {
-        super.init(frame: frame)
+    public init(descriptionText: String) {
+        super.init(frame: .zero)
+        descriptionLabel.text = descriptionText
         addSubViews()
     }
     

--- a/Projects/Features/FeatureFriendList/FeatureFriendListPresentation/Sources/FriendListViewController/FriendListViewController.swift
+++ b/Projects/Features/FeatureFriendList/FeatureFriendListPresentation/Sources/FriendListViewController/FriendListViewController.swift
@@ -44,10 +44,12 @@ public final class FriendListViewController: LifePoopViewController, ViewType {
         return collectionView
     }()
     
-    private let emptyFriendListView: EmptyFriendListView = {
-        let emptyFriendListView = EmptyFriendListView()
-        emptyFriendListView.isHidden = true
-        return emptyFriendListView
+    private let emptyFriendListView: EmptyStoolCharacterView = {
+        let emptyStoolCharacterView = EmptyStoolCharacterView(
+            descriptionText: LocalizableString.inviteFriendsAndEncourageBowelMovements
+        )
+        emptyStoolCharacterView.isHidden = true
+        return emptyStoolCharacterView
     }()
     
     private let toastLabel: ToastLabel = {

--- a/Projects/Features/FeatureHome/FeatureHomeCoordinator/Sources/DefaultHomeCoordinator.swift
+++ b/Projects/Features/FeatureHome/FeatureHomeCoordinator/Sources/DefaultHomeCoordinator.swift
@@ -53,6 +53,8 @@ public final class DefaultHomeCoordinator: HomeCoordinator {
                 self?.flowCompletionDelegate?.finishFlow()
             case .cheeringButtonDidTap(let storyFeedsStream):
                 self?.startFriendListCoordinatorFlow(storyFeedsStream: storyFeedsStream)
+            case .stoolLogButtonDidTapInReportView:
+                self?.navigationController.popViewController(animated: true)
             case .stoolLogButtonDidTap(let stoolLogsRelay):
                 self?.startStoolLogCoordinatorFlow(stoolLogsRelay: stoolLogsRelay)
             case .settingButtonDidTap:

--- a/Projects/Features/FeatureHome/FeatureHomeCoordinatorInterface/Sources/HomeCoordinatorAction.swift
+++ b/Projects/Features/FeatureHome/FeatureHomeCoordinatorInterface/Sources/HomeCoordinatorAction.swift
@@ -16,6 +16,7 @@ public enum HomeCoordinateAction {
     case flowDidStart(animated: Bool)
     case flowDidFinish
     case cheeringButtonDidTap(storyFeedsStream: BehaviorRelay<[StoryFeedEntity]>)
+    case stoolLogButtonDidTapInReportView
     case stoolLogButtonDidTap(stoolLogsRelay: BehaviorRelay<[StoolLogEntity]>)
     case settingButtonDidTap
     case reportButtonDidTap

--- a/Projects/Features/FeatureReport/FeatureReportPresentation/Sources/ReportView/ReportTotalColorView.swift
+++ b/Projects/Features/FeatureReport/FeatureReportPresentation/Sources/ReportView/ReportTotalColorView.swift
@@ -20,6 +20,13 @@ final class ReportTotalColorView: UIView {
     
     private var colorBars: [StoolCountBarView] = []
     
+    private let emptyLabel: UILabel = {
+        let label = UILabel()
+        label.text = LocalizableString.noStoolLogForPeriod
+        label.textColor = .darkGray
+        return label
+    }()
+    
     private let barViewStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .vertical
@@ -39,6 +46,7 @@ final class ReportTotalColorView: UIView {
     }
     
     func updateColorBars(with stoolColorReports: [StoolColorReport]) {
+        emptyLabel.isHidden = !stoolColorReports.isEmpty
         clearColorBars()
         stoolColorReports.forEach {
             updateColorBar(
@@ -51,9 +59,15 @@ final class ReportTotalColorView: UIView {
     
     private func layoutUI() {
         addSubview(barViewStackView)
+        addSubview(emptyLabel)
         
         barViewStackView.snp.makeConstraints { make in
             make.edges.equalToSuperview()
+        }
+        
+        emptyLabel.snp.makeConstraints { make in
+            make.top.bottom.equalToSuperview().inset(16)
+            make.centerX.equalToSuperview()
         }
     }
 }

--- a/Projects/Features/FeatureReport/FeatureReportPresentation/Sources/ReportView/ReportTotalShapeView.swift
+++ b/Projects/Features/FeatureReport/FeatureReportPresentation/Sources/ReportView/ReportTotalShapeView.swift
@@ -117,18 +117,13 @@ final class ReportTotalShapeView: UIView {
 }
 
 extension ReportTotalShapeView {
-    func updateTotalShape(by stoolShapeCountMap: [StoolShape: Int]) {
-        let sortedShapes = stoolShapeCountMap.sorted { $0.value > $1.value }
-        let stoolShapeTypeCount = StoolShape.allCases.count
-        
-        guard sortedShapes.count >= stoolShapeTypeCount else { return }
-        
+    func updateTotalShape(by stoolShapeCounts: [(stoolShape: StoolShape, count: Int)]) {
         let imageViews = [firstStoolImageView, secondStoolImageView, thirdtoolImageView]
         let labels = [firstTextLabel, secondTextLabel, thirdTextLabel]
         
-        for index in 0..<stoolShapeTypeCount {
-            let shape = sortedShapes[index].key
-            let count = sortedShapes[index].value
+        for (index, item) in stoolShapeCounts.enumerated() {
+            let shape = item.stoolShape
+            let count = item.count
             setImageViewAndLabel(for: shape, count: count, imageView: imageViews[index], label: labels[index])
         }
     }

--- a/Projects/Features/FeatureReport/FeatureReportPresentation/Sources/ReportViewController.swift
+++ b/Projects/Features/FeatureReport/FeatureReportPresentation/Sources/ReportViewController.swift
@@ -30,6 +30,21 @@ public final class ReportViewController: LifePoopViewController, ViewType {
     private let scrollView = UIScrollView()
     private let scrollContentView = UIView()
     
+    private let emptyReportView: EmptyStoolCharacterView = {
+        let emptyStoolCharacterView = EmptyStoolCharacterView(
+            descriptionText: LocalizableString.emptyStoolReport
+        )
+        emptyStoolCharacterView.isHidden = true
+        return emptyStoolCharacterView
+    }()
+    
+    private let stoolLogButton: LifePoopButton = {
+        let button = LifePoopButton()
+        button.setTitle(LocalizableString.logStoolDiary, for: .normal)
+        button.isHidden = true
+        return button
+    }()
+    
     private let periodSegmentControl = LifePoopSegmentControl()
     
     private let reportTotalStoolCountView = ReportTotalStoolCountView()
@@ -100,6 +115,10 @@ public final class ReportViewController: LifePoopViewController, ViewType {
         periodSegmentControl.rx.selectedSegmentIndex
             .bind(to: input.periodDidSelect)
             .disposed(by: disposeBag)
+        
+        stoolLogButton.rx.tap
+            .bind(to: input.stoolLogButtonDidTap)
+            .disposed(by: disposeBag)
     }
     
     public func bindOutput(from viewModel: ReportViewModel) {
@@ -118,6 +137,17 @@ public final class ReportViewController: LifePoopViewController, ViewType {
         output.selectPeriodSegmentIndexAt
             .asSignal()
             .emit(to: periodSegmentControl.rx.selectedSegmentIndex)
+            .disposed(by: disposeBag)
+        
+        output.showEmptyReportView
+            .asSignal()
+            .withUnretained(self)
+            .debug()
+            .emit { `self`, _ in
+                self.emptyReportView.isHidden = false
+                self.stoolLogButton.isHidden = false
+                self.scrollContentView.isHidden = true
+            }
             .disposed(by: disposeBag)
         
         output.updateStoolCountInfo
@@ -171,6 +201,8 @@ public final class ReportViewController: LifePoopViewController, ViewType {
         }
         
         view.addSubview(scrollView)
+        view.addSubview(emptyReportView)
+        view.addSubview(stoolLogButton)
         view.addSubview(loadingIndicator)
         view.addSubview(toastMessageLabel)
         scrollView.addSubview(scrollContentView)
@@ -184,6 +216,15 @@ public final class ReportViewController: LifePoopViewController, ViewType {
         scrollView.snp.makeConstraints {
             $0.top.leading.trailing.equalTo(view.safeAreaLayoutGuide)
             $0.bottom.equalToSuperview()
+        }
+        
+        emptyReportView.snp.makeConstraints { make in
+            make.edges.equalTo(view.safeAreaLayoutGuide)
+        }
+        
+        stoolLogButton.snp.makeConstraints { make in
+            make.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(32)
+            make.bottom.equalTo(view.safeAreaLayoutGuide).inset(18)
         }
         
         loadingIndicator.snp.makeConstraints { make in

--- a/Projects/Utils/Resources/Localizable.strings
+++ b/Projects/Utils/Resources/Localizable.strings
@@ -95,6 +95,8 @@
 
 /* 리포트 */
 "stoolLogReport" = "변 기록 리포트";
+"noStoolLogForPeriod" = "해당 기간에 기록된 변이 없어요!";
+"emptyStoolReport" = "아직 기록된 변 기록이 없어요";
 "recent" = "최근";
 "sevenDays" = "7일";
 "oneMonth" = "1개월";


### PR DESCRIPTION
### 🔖 관련 이슈
- #168

<br> 

### ⚒️ 작업 내역

- [x] 변 기록 리포트 화면에서, 기록된 변의 횟수가 동일할 경우 지정된 순서로 나타나도록 수정

<br>

### 📑 첨부 자료

|회원 가입 후 변을 한 번도 기록하지 않은 경우|선택된 기간 내에 기록된 변이 없는 경우|
|-----|-----|
|![image](https://github.com/LifePoop/LifePoop_iOS/assets/57667738/89feed91-ce71-4271-9133-c38cf685f5b9)|![image](https://github.com/LifePoop/LifePoop_iOS/assets/57667738/bc1d9590-472d-4ad5-a235-768efee4bd6c)|

(리포트 화면의 변 기록하기를 누를 경우, 홈 화면으로 navigation pop 됩니다)

https://github.com/LifePoop/LifePoop_iOS/assets/57667738/ef7bc1d0-6bdc-474a-8e06-5bfd33e29172


