### PR TITLE
탈퇴하기 요청 후 응답 오기 전까지 화면 터치 막기 처리

### DIFF
--- a/Projects/Features/FeatureSetting/FeatureSettingPresentation/Sources/SettingViewController.swift
+++ b/Projects/Features/FeatureSetting/FeatureSettingPresentation/Sources/SettingViewController.swift
@@ -140,6 +140,17 @@ public final class SettingViewController: LifePoopViewController, ViewType {
                 self.showSystemAlert(title: alert.title, message: alert.message)
             })
             .disposed(by: disposeBag)
+        
+        output.blockScreen
+            .asDriver(onErrorJustReturn: false)
+            .drive(with: self, onNext: { `self`, shouldBlock in
+                if shouldBlock {
+                    self.blockScreen()
+                } else {
+                    self.unblockScreen()
+                }
+            })
+            .disposed(by: disposeBag)
     }
     
     // MARK: - UI Setup

--- a/Projects/Utils/Sources/Extension/UIViewController+blockScreen.swift
+++ b/Projects/Utils/Sources/Extension/UIViewController+blockScreen.swift
@@ -1,0 +1,94 @@
+//
+//  UIViewController+blockScreen.swift
+//  Utils
+//
+//  Created by Lee, Joon Woo on 2023/12/23.
+//  Copyright © 2023 Lifepoo. All rights reserved.
+//
+
+import UIKit
+
+private var blockViewKey: Void?
+
+private final class BlockView: UIView {
+    
+    private let loadingIndicator: UIActivityIndicatorView = {
+        let view = UIActivityIndicatorView(style: .large)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setDimmedEffect()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setDimmedEffect()
+    }
+    
+    
+    private func setDimmedEffect() {
+        backgroundColor = .black.withAlphaComponent(0.5)
+
+        addSubview(loadingIndicator)
+        loadingIndicator.startAnimating()
+        
+        NSLayoutConstraint.activate([
+            loadingIndicator.centerXAnchor.constraint(equalTo: centerXAnchor),
+            loadingIndicator.centerYAnchor.constraint(equalTo: centerYAnchor)
+        ])
+    }
+}
+
+public extension UIViewController {
+
+    private var blockView: BlockView? {
+        get {
+            objc_getAssociatedObject(self, &blockViewKey) as? BlockView
+        }
+        set {
+            if let previousView = blockView {
+                previousView.removeFromSuperview()
+            }
+            
+            objc_setAssociatedObject(self, &blockViewKey, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        }
+    }
+
+    func blockScreen() {
+        self.addBlockView()
+
+        view.isUserInteractionEnabled = true
+        navigationItem.hidesBackButton = true
+    }
+    
+    func unblockScreen() {
+        self.removeBlockView()
+        
+        view.isUserInteractionEnabled = true
+        navigationItem.hidesBackButton = false
+    }
+    
+    private func addBlockView() {
+        let blockView = BlockView()
+        blockView.translatesAutoresizingMaskIntoConstraints = false
+        self.blockView = blockView
+
+        view.addSubview(blockView)
+        NSLayoutConstraint.activate([
+            blockView.topAnchor.constraint(equalTo: view.topAnchor),
+            blockView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            blockView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            blockView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        ])
+        
+        view.setNeedsLayout()
+    }
+    
+    private func removeBlockView() {
+        blockView?.removeFromSuperview()
+        blockView = nil
+    }
+}


### PR DESCRIPTION
### 🔖 관련 이슈
- #181 

<br> 

### ⚒️ 작업 내역

- [x] 탈퇴하기 요청 후 응답 오기 전까지 화면 터치 막기 처리

<br>

### 💻 리뷰어 가이드
- 애플 로그인>탈퇴하기 요청>응답 올 때 까지 화면이 막혀있으면 됩니다.

<br>

### 📑 첨부 
![Simulator Screen Recording - iPhone 12 mini - 2023-12-23 at 21 49 55](https://github.com/LifePoop/LifePoop_iOS/assets/68586291/83ff6e5a-6969-4be7-84e8-4ec93d06fe3c)
자료
