### PR TITLE
회원가입시 생년월일 입력 관련 버그 수정

### DIFF
--- a/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/SignupScene/SignupViewModel.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginPresentation/Sources/SignupScene/SignupViewModel.swift
@@ -189,10 +189,11 @@ public final class SignupViewModel: ViewModelType {
             .flatMap { `self`, signupInfo in
                 Observable.combineLatest(
                     self.signupUseCase.isNicknameInputValid(signupInfo.nickname).map { $0.isValid },
-                    self.signupUseCase.isAllEsssentialConditionsSelected(signupInfo.conditions)
+                    self.signupUseCase.isAllEsssentialConditionsSelected(signupInfo.conditions),
+                    self.signupUseCase.isBirthdayInputValid(signupInfo.birthDate ?? "").map { $0.status != .impossible }
                 )
             }
-            .map { $0 && $1 }
+            .map { $0 && $1 && $2 }
             .bind(to: output.activateNextButton)
             .disposed(by: disposeBag)
         

--- a/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/DefaultSignupUseCase.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginUseCase/Sources/DefaultSignupUseCase.swift
@@ -99,7 +99,7 @@ public final class DefaultSignupUseCase: SignupUseCase {
         let isValid = getBirthdayInputValidation(input)
         
         if isEmpty {
-            return Observable.just(.init(isValid: isValid, status: .defaultWarning))
+            return Observable.just(.init(isValid: true, status: .default))
         }
         switch isValid {
         case true:


### PR DESCRIPTION
### 🔖 관련 이슈
- #189

<br> 

### ⚒️ 작업 내역

- [x] 생년월일을 입력했다가 지우면 '생년월일 6자를 입력해주세요' 경고 라벨이 빨간색으로 표시됨 -> 검은색으로 변경
- [x] 올바른 생년월일을 입력하지 않았음에도 '다음' 버튼이 활성화됨 -> 비활성화되게 변경

<br>

### 📝 부가 설명

회원가입에 필요한 생년월일 필드가 옵셔널로 변경된 이후,
'다음' 버튼 활성화에 대한 로직 처리와
생년월일을 입력했다가 지울 경우 라벨이 빨간색으로 남아있는 현상이 있어
이 부분들을 해결하였습니다.

<br> 

### 📑 첨부 자료

- 작업 이전

https://github.com/LifePoop/LifePoop_iOS/assets/57667738/77875372-8139-4a48-8b09-c288dd0a063b

- 작업 이후

https://github.com/LifePoop/LifePoop_iOS/assets/57667738/236f118e-6b57-45ce-b337-d155b37ef2d1
