### PR TITLE
사용자 정보 디코딩 할 때 생년월일, 성별 정보를 옵셔널로 수정

### DIFF
--- a/Projects/Core/CoreEntity/Sources/GenderType.swift
+++ b/Projects/Core/CoreEntity/Sources/GenderType.swift
@@ -35,7 +35,8 @@ public enum GenderType: Int, CaseIterable, CustomStringConvertible, Codable {
         }
     }    
     
-    public init?(stringValue: String) {
+    public init?(stringValue: String?) {
+        guard let stringValue = stringValue else { return nil }
         switch stringValue.uppercased() {
         case "MALE":
             self = .male

--- a/Projects/Core/CoreEntity/Sources/UserInfoEntity.swift
+++ b/Projects/Core/CoreEntity/Sources/UserInfoEntity.swift
@@ -12,8 +12,8 @@ public struct UserInfoEntity: Codable {
     
     public let userId: Int
     public let nickname: String
-    public let birthDate: String
-    public let genderType: GenderType
+    public let birthDate: String?
+    public let genderType: GenderType?
     public let profileCharacter: ProfileCharacter
     public let invitationCode: String
     public let authInfo: UserAuthInfoEntity
@@ -21,8 +21,8 @@ public struct UserInfoEntity: Codable {
     public init(
         userId: Int,
         nickname: String,
-        birthDate: String,
-        genderType: GenderType,
+        birthDate: String?,
+        genderType: GenderType?,
         profileCharacter: ProfileCharacter,
         invitationCode: String,
         authInfo: UserAuthInfoEntity) {

--- a/Projects/Core/CoreNetworkService/Sources/DTO/UserInfoDTO.swift
+++ b/Projects/Core/CoreNetworkService/Sources/DTO/UserInfoDTO.swift
@@ -12,8 +12,8 @@ public struct UserInfoDTO: Codable {
     
     public let id: Int
     public let nickname: String
-    public let birth: String
-    public let sex: String
+    public let birth: String?
+    public let sex: String?
     public let characterColor: Int
     public let characterShape: Int
     public let inviteCode: String

--- a/Projects/Shared/SharedRepository/Sources/DefaultUserInfoRepository.swift
+++ b/Projects/Shared/SharedRepository/Sources/DefaultUserInfoRepository.swift
@@ -80,8 +80,7 @@ public final class DefaultUserInfoRepository: UserInfoRepository {
             .fetchData(endpoint: LifePoopLocalTarget.fetchUserInfo(accessToken: authInfo.accessToken))
             .decodeMap(UserInfoDTO.self)
             .map { dto in
-                guard let genderType = GenderType(stringValue: dto.sex),
-                      let profileColor = StoolColor(rawValue: dto.characterColor),
+                guard let profileColor = StoolColor(rawValue: dto.characterColor),
                       let profileShape = StoolShape(rawValue: dto.characterShape) else {
                     throw NetworkError.dataMappingError
                 }
@@ -90,7 +89,7 @@ public final class DefaultUserInfoRepository: UserInfoRepository {
                     userId: dto.id,
                     nickname: dto.nickname,
                     birthDate: dto.birth,
-                    genderType: genderType,
+                    genderType:  GenderType(stringValue:  dto.sex),
                     profileCharacter: ProfileCharacter(color: profileColor, shape: profileShape),
                     invitationCode: dto.inviteCode,
                     authInfo: authInfo

--- a/Projects/Shared/SharedUseCase/Sources/DefaultUserInfoUseCase.swift
+++ b/Projects/Shared/SharedUseCase/Sources/DefaultUserInfoUseCase.swift
@@ -33,14 +33,26 @@ public final class DefaultUserInfoUseCase: UserInfoUseCase {
             .catchAndReturn(nil)
             .asObservable()
         
-        let userId: Observable<Int?> = userDefaultsRepository.getValue(for: .userId).asObservable()
-        let nickname: Observable<String?> = userDefaultsRepository.getValue(for: .userNickname).asObservable()
-        let birthDate: Observable<String?> = userDefaultsRepository.getValue(for: .birthDate).asObservable()
-        let genderType: Observable<GenderType?> = userDefaultsRepository.getValue(for: .genderType).asObservable()
-        let invitationCode: Observable<String?> = userDefaultsRepository.getValue(for: .invitationCode).asObservable()
-        let profileCharacter: Observable<ProfileCharacter?> = userDefaultsRepository.getValue(
-            for: .profileCharacter
-        ).asObservable()
+        let userId: Observable<Int?> = userDefaultsRepository
+            .getValue(for: .userId)
+            .asObservable()
+        let nickname: Observable<String?> = userDefaultsRepository
+            .getValue(for: .userNickname)
+            .asObservable()
+        let birthDate: Observable<String?> = userDefaultsRepository
+            .getValue(for: .birthDate)
+            .catchAndReturn(nil)
+            .asObservable()
+        let genderType: Observable<GenderType?> = userDefaultsRepository
+            .getValue(for: .genderType)
+            .catchAndReturn(nil)
+            .asObservable()
+        let invitationCode: Observable<String?> = userDefaultsRepository
+            .getValue(for: .invitationCode)
+            .asObservable()
+        let profileCharacter: Observable<ProfileCharacter?> = userDefaultsRepository
+            .getValue(for: .profileCharacter)
+            .asObservable()
         
         return Observable.combineLatest(
             userAuthInfo,
@@ -55,8 +67,6 @@ public final class DefaultUserInfoUseCase: UserInfoUseCase {
             guard let authInfo = authInfo,
                   let userId = userId,
                   let nickname = nickname,
-                  let birthDate = birthDate,
-                  let genderType = genderType,
                   let invitationCode = invitationCode,
                   let profileCharacter = profileCharacter else { return nil }
             


### PR DESCRIPTION
### 🔖 관련 이슈
- #191

<br> 

### ⚒️ 작업 내역

- [x] 성별, 생년월일 관련 필드 옵셔널로 변경

<br>

### 💻 리뷰어 가이드
- 회원가입, 로그인, 기타 CRUD 작업이 기존과 동일하게 정상적으로 동작하면 됩니다.
- 우선 회원가입, 로그인, 변 기록 불러오기, 리포트 정보 불러오기 등은 아래 케이스로 확인했는데 혹시 보고 또 문제 있으시면 피드백 부탁드려요
    - 모든 회원가입 정보 기입 후, 회원가입 후 로그인 확인
    - 성별 항목만 미기입 후 회원가입 후 로그인 확인
    - 생년월일 항목만 미기입 후 회원가입 후 로그인 확인
    - 성별, 생년월일 항목 모두 미기입 후 회원가입 후 로그인 확인 