### PR TITLE
카카오톡 앱 설치 안되있을 경우 브라우저 통해서 로그인하도록 수정

### DIFF
--- a/Projects/Core/CoreAuthentication/Sources/AuthenticationError.swift
+++ b/Projects/Core/CoreAuthentication/Sources/AuthenticationError.swift
@@ -10,15 +10,18 @@ import Foundation
 
 public enum AuthenticationError: LocalizedError {
     case authInfoNotInitialized
-    case appleLoginViewClosed
+    case kakaoLoginCancelledByUser
+    case appleLoginCancelledByUser
     case authTokenNil
     
     public var errorDescription: String? {
         switch self {
         case .authInfoNotInitialized:
             return "인증 정보가 초기화되지 않았습니다."
-        case .appleLoginViewClosed:
-            return "사용자가 임의로 애플 로그인 창을 닫은 상태"
+        case .kakaoLoginCancelledByUser:
+            return "사용자가 카카오 로그인을 취소한 상태"
+        case .appleLoginCancelledByUser:
+            return "사용자가 애플 로그인을 취소한 상태"
         case .authTokenNil:
             return "인증 토큰이 존재하지 않습니다.(nil value)"
         }

--- a/Projects/Core/CoreAuthentication/Sources/AuthenticationError.swift
+++ b/Projects/Core/CoreAuthentication/Sources/AuthenticationError.swift
@@ -11,15 +11,12 @@ import Foundation
 public enum AuthenticationError: LocalizedError {
     case authInfoNotInitialized
     case appleLoginViewClosed
-    case kakaoTalkLoginNotAvailable
     case authTokenNil
     
     public var errorDescription: String? {
         switch self {
         case .authInfoNotInitialized:
             return "인증 정보가 초기화되지 않았습니다."
-        case .kakaoTalkLoginNotAvailable:
-            return "카카오 로그인이 현재 불가합니다.\n카카오톡 설치 여부를 확인해주세요"
         case .appleLoginViewClosed:
             return "사용자가 임의로 애플 로그인 창을 닫은 상태"
         case .authTokenNil:

--- a/Projects/Core/CoreAuthentication/Sources/Managers/ASAuthorizationControllerProxy.swift
+++ b/Projects/Core/CoreAuthentication/Sources/Managers/ASAuthorizationControllerProxy.swift
@@ -8,8 +8,8 @@
 
 import AuthenticationServices
 
-import RxSwift
 import RxCocoa
+import RxSwift
 
 extension ASAuthorizationController: HasDelegate {
     public typealias Delegate = ASAuthorizationControllerDelegate
@@ -46,7 +46,7 @@ public final class ASAuthorizationControllerProxy: DelegateProxy<ASAuthorization
         if let error = error as? ASAuthorizationError {
             switch error.errorCode {
             case 1001:
-                didComplete.onError(AuthenticationError.appleLoginViewClosed)
+                didComplete.onError(AuthenticationError.appleLoginCancelledByUser)
             default:
                 didComplete.onError(error)
             }

--- a/Projects/Features/FeatureLogin/FeatureLoginRepository/Sources/DefaultLoginRepository.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginRepository/Sources/DefaultLoginRepository.swift
@@ -41,7 +41,7 @@ public final class DefaultLoginRepository: NSObject, LoginRepository {
                 
                 let isAuthenticationProcessCancelledByUser =
                     error == .kakaoLoginCancelledByUser
-                    || error == .appleLoginViewClosed
+                    || error == .appleLoginCancelledByUser
                 
                 if isAuthenticationProcessCancelledByUser {
                     return Single.just("")

--- a/Projects/Features/FeatureLogin/FeatureLoginRepository/Sources/DefaultLoginRepository.swift
+++ b/Projects/Features/FeatureLogin/FeatureLoginRepository/Sources/DefaultLoginRepository.swift
@@ -33,9 +33,17 @@ public final class DefaultLoginRepository: NSObject, LoginRepository {
    
     public func fetchOAuthAccessToken(for loginType: LoginType) -> Single<String> {
         authManager(for: loginType).fetchAccessToken()
+            .logErrorIfDetected(category: .authentication)
             .catch { error in
-                if let authenticationError = error as? AuthenticationError,
-                   authenticationError == .appleLoginViewClosed {
+                guard let error = error as? AuthenticationError else {
+                    return .error(error)
+                }
+                
+                let isAuthenticationProcessCancelledByUser =
+                    error == .kakaoLoginCancelledByUser
+                    || error == .appleLoginViewClosed
+                
+                if isAuthenticationProcessCancelledByUser {
                     return Single.just("")
                 }
                 


### PR DESCRIPTION
### 🔖 관련 이슈
- #193 

<br> 

### ⚒️ 작업 내역

- [x] 카카오톡 앱 설치 안되있을 경우 웹브라우저 통해서 로그인 가능 하도록 수정

<br>

### 💻 리뷰어 가이드
> 카카오톡이 설치되지 않은 환경에서 확인하시면 됩니다. 저는 시뮬레이터로 확인했어요 우선

- 기존에 카카오톡 통해서 회원가입한 경우
  - 카카오 로그인 버튼 터치 > 웹브라우저 확인 > 카카오 로그인 진행 > 정상적으로 홈 화면 진입 확인 
- 카카오톡 통해서 회원가입 하지 않은 경우
   - 카카오 로그인 버튼 터치 > 웹브라우저  확인 > 카카오 로그인 진행 > 정상적으로 회원가입 화면 진입 확인

<br>

### 📝 부가 설명
- 웹브라우저 통한 로그인은 [카카오 웹 로그인 관련 문서](https://developers.kakao.com/docs/latest/ko/kakaologin/ios#login-with-kakaoaccount)를 참고했어요
- KakaoAuthManager.swift 보시면 리턴값이랑 에러 처리를 [내부함수 통해서 처리](https://github.com/LifePoop/LifePoop_iOS/pull/194/commits/935d39643f9b9204a1d8f66698a0b9cb41a2b859)하도록 해놨는데.. 원래는 외부에 인스턴스 함수로 빼려다가 이럴 경우 self 메모리가 해제되가지고.. 우선 이렇게 했어요

<br> 

### 📑 첨부 자료

|이미 가입된 경우|새로 가입해야 하는 경우|
|-----|-----|
|![Simulator Screen Recording - iPhone 12 mini - 2024-01-06 at 13 38 08](https://github.com/LifePoop/LifePoop_iOS/assets/68586291/fe5b00d3-1a7c-4f62-810f-96e9085e3f52)|![Simulator Screen Recording - iPhone 12 mini - 2024-01-06 at 13 38 42](https://github.com/LifePoop/LifePoop_iOS/assets/68586291/1019ee5c-7154-4387-9aea-e0fba0410cbe)|

